### PR TITLE
PatternMatch: migrate to CmpPredicate after 4a0d53a0b0a5

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1434,7 +1434,7 @@ bool usesSpvExtImageRaw10Raw12Constants(const CallInst *CI) {
   // common use patterns here.
   for (auto *U : CI->users()) {
     for (auto C : ExtConstants) {
-      ICmpInst::Predicate Pred;
+      CmpPredicate Pred;
       if (match(U, m_c_ICmp(Pred, m_Value(), m_SpecificInt(C)))) {
         return true;
       }


### PR DESCRIPTION
Taken from https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2928