### PR TITLE
[HeterogeneousDwarf] Support translation of DIOp-based DIExpressions

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1208,7 +1208,7 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
     Ops.push_back(transDbgEntry(StaticMember)->getId());
 
   // Check if Ops[VariableIdx] has no information
-  if (isNonSemanticDebugInfo() && Ops[VariableIdx] == getDebugInfoNoneId()) {
+  if (isNonSemanticDebugInfo()) {
     // Check if GV has an associated GVE with a non-empty DIExpression.
     // The non-empty DIExpression gives the initial value of the GV.
     for (const DIGlobalVariableExpression *GVE : DIF.global_variables()) {
@@ -1216,6 +1216,14 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
           GVE->getVariable() == GV &&
           // DIExpression is non-empty
           GVE->getExpression()->getNumElements()) {
+        if (Ops[VariableIdx] != getDebugInfoNoneId()) {
+          if (GVE->getExpression()->holdsNewElements()) {
+            Ops.resize(MaxOperandCount, getDebugInfoNoneId());
+            Ops[DIOpBasedExprIdx] =
+              transDbgExpression(GVE->getExpression())->getId();
+          }
+          break;
+        }
         // Repurpose VariableIdx operand to hold the initial value held in the
         // GVE's DIExpression
         Ops[VariableIdx] = transDbgExpression(GVE->getExpression())->getId();
@@ -1632,8 +1640,6 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgExpression(const DIExpression *Expr) {
   SPIRVWordVec Operations;
 
   if (auto NewElems = Expr->getNewElementsRef()) {
-    using namespace SPIRVDebug::Operand::Operation;
-
     if (!(BM->allowExtraDIExpressions() ||
           BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200))
       report_fatal_error(
@@ -1693,12 +1699,11 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgExpression(const DIExpression *Expr) {
     SPIRVDebug::ExpressionOpCode OC =
         SPIRV::DbgExpressionOpCodeMap::map(DWARFOpCode);
     if (OpCountMap.find(OC) == OpCountMap.end())
-      report_fatal_error(llvm::Twine("unknown opcode found in DIExpression"));
+      report_fatal_error("unknown opcode found in DIExpression");
     if (OC > SPIRVDebug::Fragment &&
         !(BM->allowExtraDIExpressions() ||
           BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200))
-      report_fatal_error(
-          llvm::Twine("unsupported opcode found in DIExpression"));
+      report_fatal_error("unsupported opcode found in DIExpression");
 
     unsigned OpCount = OpCountMap[OC];
     SPIRVWordVec Op(OpCount);

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1608,8 +1608,84 @@ LLVMToSPIRVDbgTran::transDbgLocalVariable(const DILocalVariable *Var) {
 
 // DWARF Operations and expressions
 
+template <>
+void LLVMToSPIRVDbgTran::transDIOpOperand(SPIRVWordVec &Vec, unsigned Idx,
+                                          llvm::Type *Ty) {
+  Vec[Idx] = SPIRVWriter->transType(Ty)->getId();
+}
+
+template <>
+void LLVMToSPIRVDbgTran::transDIOpOperand(SPIRVWordVec &Vec, unsigned Idx,
+                                          uint32_t UInt) {
+  Vec[Idx] = UInt;
+  if (isNonSemanticDebugInfo())
+    transformToConstant(Vec, {Idx});
+}
+
+template <>
+void LLVMToSPIRVDbgTran::transDIOpOperand(SPIRVWordVec &Vec, unsigned Idx,
+                                          llvm::ConstantData *Data) {
+  Vec[Idx] = SPIRVWriter->transConstant(Data)->getId();
+}
+
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgExpression(const DIExpression *Expr) {
   SPIRVWordVec Operations;
+
+  if (auto NewElems = Expr->getNewElementsRef()) {
+    using namespace SPIRVDebug::Operand::Operation;
+
+    if (!(BM->allowExtraDIExpressions() ||
+          BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200))
+      report_fatal_error(
+          llvm::Twine("unsupported DIOp-based opcode found in DIExpression"));
+
+    for (DIOp::Variant DIOp : *NewElems) {
+      using namespace SPIRVDebug::Operand::Operation;
+
+      unsigned BitcodeID = llvm::DIOp::getBitcodeID(DIOp);
+      SPIRVDebug::ExpressionOpCode OC =
+          SPIRV::DbgExpressionDIOpBasedOpCodeMap::map(BitcodeID);
+      if (OpCountMap.find(OC) == OpCountMap.end())
+        report_fatal_error(
+            llvm::Twine("unknown DIOp-based opcode found in DIExpression"));
+
+      unsigned OpCount = OpCountMap[OC];
+      SPIRVWordVec Op(OpCount);
+      Op[OpCodeIdx] = OC;
+      if (isNonSemanticDebugInfo())
+        transformToConstant(Op, {OpCodeIdx});
+
+#define HANDLE_OP1(Name, OpType, OpName)                                       \
+  case llvm::DIOp::Name::getBitcodeID():                                       \
+    assert(OpCount == 2);                                                      \
+    transDIOpOperand<OpType>(Op, 1,                                            \
+                             std::get<llvm::DIOp::Name>(DIOp).get##OpName());  \
+    break;
+#define HANDLE_OP2(Name, OpType1, OpName1, OpType2, OpName2)                   \
+  case llvm::DIOp::Name::getBitcodeID():                                       \
+    assert(OpCount == 3);                                                      \
+    transDIOpOperand<OpType1>(                                                 \
+        Op, 1, std::get<llvm::DIOp::Name>(DIOp).get##OpName1());               \
+    transDIOpOperand<OpType2>(                                                 \
+        Op, 2, std::get<llvm::DIOp::Name>(DIOp).get##OpName2());               \
+    break;
+
+      switch (BitcodeID) {
+#include "llvm/IR/DIExprOps.def"
+      default:
+        // This is the OP0 case.
+        assert(OpCount == 1);
+        break;
+      }
+
+      auto *Operation =
+          BM->addDebugInfo(SPIRVDebug::Operation, getVoidTy(), Op);
+      Operations.push_back(Operation->getId());
+    }
+
+    return BM->addDebugInfo(SPIRVDebug::Expression, getVoidTy(), Operations);
+  }
+
   for (unsigned I = 0, N = Expr->getNumElements(); I < N; ++I) {
     using namespace SPIRVDebug::Operand::Operation;
     auto DWARFOpCode = static_cast<dwarf::LocationAtom>(Expr->getElement(I));

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -159,6 +159,9 @@ private:
   // DWARF expressions
   SPIRVEntry *transDbgExpression(const DIExpression *Expr);
 
+  template <class OperandTy>
+  void transDIOpOperand(SPIRVWordVec &Vec, unsigned Idx, OperandTy Operand);
+
   // Imported declarations and modules
   SPIRVEntry *transDbgImportedEntry(const DIImportedEntity *IE);
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1125,7 +1125,8 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   StringRef LinkageName = getString(Ops[LinkageNameIdx]);
 
   DIDerivedType *StaticMemberDecl = nullptr;
-  if (Ops.size() > MinOperandCount) {
+  if (Ops.size() > MinOperandCount &&
+      !getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[StaticMemberDeclarationIdx])) {
     StaticMemberDecl = transDebugInst<DIDerivedType>(
         BM->get<SPIRVExtInst>(Ops[StaticMemberDeclarationIdx]));
   }
@@ -1137,6 +1138,9 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   if (getDbgInst<SPIRVDebug::Expression>(Ops[VariableIdx]))
     DIExpr =
         transDebugInst<DIExpression>(BM->get<SPIRVExtInst>(Ops[VariableIdx]));
+  else if (Ops.size() > DIOpBasedExprIdx)
+    DIExpr = transDebugInst<DIExpression>(
+        BM->get<SPIRVExtInst>(Ops[DIOpBasedExprIdx]));
 
   SPIRVWord Flags =
       getConstantValueOrLiteral(Ops, FlagsIdx, DebugInst->getExtSetKind());
@@ -1158,7 +1162,7 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
 
   // Ops[VariableIdx] was not used to hold an Expression with the initial value
   // for the GlobalVariable
-  if (!DIExpr) {
+  if (!DIExpr || Ops.size() > DIOpBasedExprIdx) {
     // If the variable has no initializer Ops[VariableIdx] is OpDebugInfoNone.
     // Otherwise Ops[VariableIdx] may be a global variable or a constant(C++
     // static const).

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1408,7 +1408,84 @@ DINode *SPIRVToLLVMDbgTran::transModule(const SPIRVExtInst *DebugInst) {
       Scope, Name, ConfigMacros, IncludePath, ApiNotes, File, Line, IsDecl);
 }
 
+template <>
+Type *SPIRVToLLVMDbgTran::transDIOpOperand(const SPIRVExtInst *DbgOpInst,
+                                           unsigned Idx) {
+  const SPIRVWordVec &Operands = DbgOpInst->getArguments();
+  SPIRVType *Ty = BM->get<SPIRVType>(Operands[Idx]);
+  return SPIRVReader->transType(Ty);
+}
+
+template <>
+uint32_t SPIRVToLLVMDbgTran::transDIOpOperand(const SPIRVExtInst *DbgOpInst,
+                                              unsigned Idx) {
+  const SPIRVWordVec &Operands = DbgOpInst->getArguments();
+  return getConstantValueOrLiteral(Operands, Idx, DbgOpInst->getExtSetKind());
+}
+
+template <>
+ConstantData *
+SPIRVToLLVMDbgTran::transDIOpOperand(const SPIRVExtInst *DbgOpInst,
+                                     unsigned Idx) {
+  const SPIRVWordVec &Operands = DbgOpInst->getArguments();
+  SPIRVValue *Val = BM->get<SPIRVValue>(Operands[Idx]);
+  return cast<ConstantData>(SPIRVReader->transValue(Val, nullptr, nullptr));
+}
+
+MDNode *
+SPIRVToLLVMDbgTran::tryTransDIOpDIExpression(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::Operation;
+
+  auto getOpcodeFromInst = [this](const SPIRVExtInst *OpInst) {
+    return static_cast<SPIRVDebug::ExpressionOpCode>(getConstantValueOrLiteral(
+        OpInst->getArguments(), OpCodeIdx, OpInst->getExtSetKind()));
+  };
+
+  const SPIRVWordVec &Args = DebugInst->getArguments();
+
+  // DIOp-based DIExpressions can't be empty.
+  if (Args.empty())
+    return nullptr;
+  const SPIRVExtInst *FirstOp = BM->get<SPIRVExtInst>(Args[0]);
+  // Check if this is a DW_OP-based expression.
+  if (getOpcodeFromInst(FirstOp) < SPIRVDebug::DIOp_Begin)
+    return nullptr;
+
+  std::vector<llvm::DIOp::Variant> DIOps;
+  for (SPIRVId A : Args) {
+    SPIRVExtInst *DbgOpInst = BM->get<SPIRVExtInst>(A);
+    auto Opcode = getOpcodeFromInst(DbgOpInst);
+    auto BitcodeID = SPIRV::DbgExpressionDIOpBasedOpCodeMap::rmap(Opcode);
+
+#define HANDLE_OP0(Name)                                                       \
+  case DIOp::Name::getBitcodeID():                                             \
+    DIOps.push_back(DIOp::Name());                                             \
+    break;
+#define HANDLE_OP1(Name, OpType, OpName)                                       \
+  case DIOp::Name::getBitcodeID():                                             \
+    DIOps.push_back(DIOp::Name(transDIOpOperand<OpType>(DbgOpInst, 1)));       \
+    break;
+#define HANDLE_OP2(Name, OpType1, OpName1, OpType2, OpName2)                   \
+  case DIOp::Name::getBitcodeID(): {                                           \
+    OpType1 First = transDIOpOperand<OpType1>(DbgOpInst, 1);                   \
+    OpType2 Second = transDIOpOperand<OpType2>(DbgOpInst, 2);                  \
+    DIOps.push_back(DIOp::Name(First, Second));                                \
+    break;                                                                     \
+  }
+
+    switch (BitcodeID) {
+    default:
+      llvm_unreachable("translating unknown DIOp!");
+#include "llvm/IR/DIExprOps.def"
+    }
+  }
+  return DIExpression::get(M->getContext(), bool(), DIOps);
+}
+
 MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
+  if (MDNode *N = tryTransDIOpDIExpression(DebugInst))
+    return N;
+
   const SPIRVWordVec &Args = DebugInst->getArguments();
   std::vector<uint64_t> Ops;
   for (SPIRVId A : Args) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -178,6 +178,10 @@ private:
 
   DINode *transModule(const SPIRVExtInst *DebugInst);
 
+  template <class OperTy>
+  OperTy transDIOpOperand(const SPIRVExtInst *DbgOpInst, unsigned Idx);
+  MDNode *tryTransDIOpDIExpression(const SPIRVExtInst *DebugInst);
+
   MDNode *transExpression(const SPIRVExtInst *DebugInst);
 
   SPIRVModule *BM;

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -596,7 +596,9 @@ enum {
   VariableIdx                = 7,
   FlagsIdx                   = 8,
   StaticMemberDeclarationIdx = 9,
-  MinOperandCount            = 9
+  MinOperandCount            = 9,
+  DIOpBasedExprIdx           = 10,
+  MaxOperandCount            = 11,
 };
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -287,6 +287,15 @@ enum ExpressionOpCode {
   LLVMArg            = 165,
   ImplicitPointerTag = 166,
   TagOffset          = 167,
+
+  // AMD-specific debug operations, padded.
+  Poisoned           = 10000,
+
+  // DIOp-based debug operations
+  DIOp_Begin,
+#define HANDLE_OP_NAME(Name)                                  \
+  DIOp##Name = DIOp_Begin + llvm::DIOp::Name::getBitcodeID(),
+#include "llvm/IR/DIExprOps.def"
 };
 
 enum ImportedEntityTag {
@@ -939,6 +948,13 @@ static std::unordered_map<ExpressionOpCode, unsigned> OpCountMap {
   { LLVMArg,            2 },
   { ImplicitPointerTag, 2 },
   { TagOffset,          2 },
+
+  { Poisoned,           1 },
+
+#define HANDLE_OP0(NAME) { DIOp##NAME, 1 },
+#define HANDLE_OP1(NAME, T1, N1) { DIOp##NAME, 2 },
+#define HANDLE_OP2(NAME, T1, N1, T2, N2) { DIOp##NAME, 3 },
+#include "llvm/IR/DIExprOps.def"
 };
 }
 
@@ -1431,6 +1447,17 @@ inline void DbgExpressionOpCodeMap::init() {
   add(dwarf::DW_OP_LLVM_arg,              SPIRVDebug::LLVMArg);
   add(dwarf::DW_OP_LLVM_implicit_pointer, SPIRVDebug::ImplicitPointerTag);
   add(dwarf::DW_OP_LLVM_tag_offset,       SPIRVDebug::TagOffset);
+
+  add(dwarf::DW_OP_LLVM_poisoned,         SPIRVDebug::Poisoned);
+}
+
+typedef SPIRVMap<unsigned, SPIRVDebug::ExpressionOpCode>
+  DbgExpressionDIOpBasedOpCodeMap;
+template <>
+inline void DbgExpressionDIOpBasedOpCodeMap::init() {
+#define HANDLE_OP_NAME(NAME)                                      \
+  add(llvm::DIOp::NAME::getBitcodeID(), SPIRVDebug::DIOp##NAME);
+#include "llvm/IR/DIExprOps.def"
 }
 
 typedef SPIRVMap<dwarf::Tag, SPIRVDebug::ImportedEntityTag>

--- a/test/DebugInfo/AMDGPU/diop-diexpression.ll
+++ b/test/DebugInfo/AMDGPU/diop-diexpression.ll
@@ -13,7 +13,7 @@
 ; CHECK-NEXT: DW_AT_external
 ; CHECK-NEXT: DW_AT_decl_file ("t.cpp")
 ; CHECK-NEXT: DW_AT_decl_line (3)
-; CHECK-NEXT: DW_AT_location (DW_OP_addrx
+; CHECK-NEXT: DW_AT_location ({{.*}} DW_OP_lit0, DW_OP_LLVM_user DW_OP_LLVM_form_aspace_address)
 
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_location ({{.*}} DW_OP_lit5, DW_OP_LLVM_user DW_OP_LLVM_form_aspace_address)

--- a/test/DebugInfo/AMDGPU/diop-diexpression.ll
+++ b/test/DebugInfo/AMDGPU/diop-diexpression.ll
@@ -1,0 +1,64 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: amd-llvm-spirv --spirv-debug-info-version=nonsemantic-shader-200 %t.bc -o %t.spv
+; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mcpu=gfx1030 -mtriple=amdgcn-amd-amdhsa -O0 -filetype=obj -o %t %t.ll
+; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
+
+;; Verify that we can produce valid dwarf from DIOp-based DIExpressions in a
+;; simple program with a global and local variable.
+
+; CHECK: DW_TAG_variable
+; CHECK-NEXT: DW_AT_name ("global")
+; CHECK-NEXT: DW_AT_type
+; CHECK-NEXT: DW_AT_external
+; CHECK-NEXT: DW_AT_decl_file ("t.cpp")
+; CHECK-NEXT: DW_AT_decl_line (3)
+; CHECK-NEXT: DW_AT_location (DW_OP_addrx
+
+; CHECK: DW_TAG_variable
+; CHECK-NEXT: DW_AT_location ({{.*}} DW_OP_lit5, DW_OP_LLVM_user DW_OP_LLVM_form_aspace_address)
+; CHECK-NEXT: DW_AT_name ("local")
+; CHECK-NEXT: DW_AT_decl_file ("t.cpp")
+; CHECK-NEXT: DW_AT_decl_line (4)
+; CHECK-NEXT: DW_AT_type
+
+target triple = "spirv64-amd-amdhsa"
+
+@global = hidden addrspace(1) externally_initialized global i32 42, align 4, !dbg !19
+
+define hidden spir_kernel void @_Z6kernelv() addrspace(4) !dbg !11 !max_work_group_size !17 {
+  %1 = alloca i32, align 4
+  %2 = addrspacecast ptr %1 to ptr addrspace(4)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpDeref(i32)), !18)
+  store i32 43, ptr addrspace(4) %2, align 4, !dbg !18
+  store i32 44, ptr addrspace(1) @global, align 4, !dbg !18
+  ret void, !dbg !18
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!opencl.ocl.version = !{!9}
+!llvm.ident = !{!10}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 21.0.0git", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !21, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.cpp", directory: "/")
+!2 = !{i32 1, !"amdhsa_code_object_version", i32 600}
+!3 = !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+!4 = !{i32 7, !"Dwarf Version", i32 5}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 1, !"wchar_size", i32 4}
+!7 = !{i32 8, !"PIC Level", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!9 = !{i32 0, i32 0}
+!10 = !{!"clang version 21.0.0"}
+!11 = distinct !DISubprogram(name: "kernel", linkageName: "_Z6kernelv", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!12 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !13)
+!13 = !{null}
+!14 = !{!15}
+!15 = !DILocalVariable(name: "local", scope: !11, file: !1, line: 4, type: !16)
+!16 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!17 = !{i32 1024, i32 1, i32 1}
+!18 = !DILocation(line: 4, column: 6, scope: !11)
+!19 = !DIGlobalVariableExpression(var: !20, expr: !DIExpression(DIOpArg(0, ptr addrspace(1)), DIOpDeref(i32)))
+!20 = distinct !DIGlobalVariable(name: "global", scope: !0, file: !1, line: 3, type: !16, isLocal: false, isDefinition: true, memorySpace: DW_MSPACE_LLVM_global)
+!21 = !{!19}

--- a/test/DebugInfo/AMDGPU/diop-ops.ll
+++ b/test/DebugInfo/AMDGPU/diop-ops.ll
@@ -1,0 +1,59 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: amd-llvm-spirv --spirv-debug-info-version=nonsemantic-shader-200 %t.bc -o %t.spv
+; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s
+
+;; Verify that we can convert various DIOps back and forth from SPIRV.
+
+; CHECK: %struct.OnlyInExpr = type { ptr addrspace(5) }
+; CHECK: !DIExpression(DIOpArg(0, %struct.OnlyInExpr), DIOpConvert(i32))
+; CHECK: !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 10), DIOpAnd())
+; CHECK: !DIExpression(DIOpArg(0, i64), DIOpFragment(11, 12))
+; CHECK: !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 13), DIOpBitOffset(i64))
+; CHECK: !DIExpression(DIOpArg(0, i64), DIOpPushLane(i64), DIOpByteOffset(i64))
+; CHECK: !DIExpression(DIOpArg(0, i8), DIOpSExt(i64))
+; CHECK: !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 15), DIOpComposite(2, i64))
+; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
+
+target triple = "spirv64-amd-amdhsa"
+
+%struct.OnlyInExpr = type { ptr }
+
+define hidden spir_kernel void @_Z6kernelv() addrspace(4) !dbg !11 !max_work_group_size !17 {
+  %1 = alloca i32, align 4
+  %2 = addrspacecast ptr %1 to ptr addrspace(4)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, %struct.OnlyInExpr), DIOpConvert(i32)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 10), DIOpAnd()), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpFragment(11, 12)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 13), DIOpBitOffset(i64)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpPushLane(i64), DIOpByteOffset(i64)), !18)
+    #dbg_declare(i8 -1, !15, !DIExpression(DIOpArg(0, i8), DIOpSExt(i64)), !18)
+    #dbg_declare(i32 14, !15, !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 15), DIOpComposite(2, i64)), !18)
+    #dbg_declare(i32 14, !15, !DIExpression(DW_OP_LLVM_poisoned), !18)
+  store i32 43, ptr addrspace(4) %2, align 4, !dbg !18
+  ret void, !dbg !18
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!opencl.ocl.version = !{!9}
+!llvm.ident = !{!10}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 21.0.0git", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.cpp", directory: "/")
+!2 = !{i32 1, !"amdhsa_code_object_version", i32 600}
+!3 = !{i32 1, !"amdgpu_printf_kind", !"hostcall"}
+!4 = !{i32 7, !"Dwarf Version", i32 5}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 1, !"wchar_size", i32 4}
+!7 = !{i32 8, !"PIC Level", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!9 = !{i32 0, i32 0}
+!10 = !{!"clang version 21.0.0"}
+!11 = distinct !DISubprogram(name: "kernel", linkageName: "_Z6kernelv", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!12 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !13)
+!13 = !{null}
+!14 = !{!15}
+!15 = !DILocalVariable(name: "local", scope: !11, file: !1, line: 4, type: !16)
+!16 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!17 = !{i32 1024, i32 1, i32 1}
+!18 = !DILocation(line: 4, column: 6, scope: !11)

--- a/test/DebugInfo/DebugDeclareUnused.cl
+++ b/test/DebugInfo/DebugDeclareUnused.cl
@@ -1,6 +1,5 @@
 // Check that we can translate llvm.dbg.declare for a local variable which was
 // deleted by mem2reg pass(disabled by default in amd-llvm-spirv)
-// XFAIL:*
 // RUN: %clang_cc1 %s -triple spir -disable-llvm-passes -debug-info-kind=standalone -emit-llvm-bc -o - | amd-llvm-spirv -spirv-mem2reg -o %t.spv
 // RUN: amd-llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/DebugInfo/DebugInfoLLVMArg.ll
+++ b/test/DebugInfo/DebugInfoLLVMArg.ll
@@ -1,7 +1,6 @@
 ; This test checks that DW_OP_LLVM_arg operation goes through round trip translation correctly.
 ; DW_OP_LLVM_arg is mapped on 165 in SPIR-V
 
-; XFAIL:*
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: amd-llvm-spirv %t.spv -to-text -o %t.spt

--- a/test/DebugInfo/DebugInfoSubrangeWithOnlyCount.spt
+++ b/test/DebugInfo/DebugInfoSubrangeWithOnlyCount.spt
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: amd-llvm-spirv -to-binary %s -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
@@ -6,21 +5,21 @@
 
 ; CHECK: !DISubrange(count: 1000)
 
-119734787 65792 393230 48 0
-2 Capability Addresses
-2 Capability Kernel
-2 Capability Int64
-2 Capability GenericPointer
+119734787 65792 393230 48 0 
+2 Capability Addresses 
+2 Capability Kernel 
+2 Capability Int64 
+2 Capability GenericPointer 
 5 ExtInstImport 1 "OpenCL.std"
 5 ExtInstImport 2 "SPIRV.debug"
-3 MemoryModel 2 2
+3 MemoryModel 2 2 
 15 EntryPoint 6 15 "__omp_offloading_811_198142f_random_fill_sp_l25"
 6 String 29 "Fortran/f.f90"
 4 String 33 "REAL*4"
 16 String 38 "random_fill_sp.DIR.OMP.TARGET.8.split.split.split.split"
 3 String 39 ""
 3 String 41 "a"
-3 Source 4 200000
+3 Source 4 200000 
 5 Name 4 "structtype"
 5 Name 16 "ascast$val"
 5 Name 17 "ascastB$val"
@@ -29,56 +28,56 @@
 5 Name 22 "structtype2"
 4 Name 26 ".ascast"
 9 ModuleProcessed "Debug info producer: Fortran"
-4 Decorate 16 FuncParamAttr 2
-4 Decorate 17 FuncParamAttr 4
-4 TypeInt 6 64 0
-4 TypeInt 10 32 0
-5 Constant 6 7 72 0
-5 Constant 6 11 1000 0
-5 Constant 6 23 1 0
-4 Constant 10 34 32
-2 TypeVoid 3
-2 TypeBool 5
-4 TypeArray 8 5 7
-3 TypeStruct 4 8
+4 Decorate 16 FuncParamAttr 2 
+4 Decorate 17 FuncParamAttr 4 
+4 TypeInt 6 64 0 
+4 TypeInt 10 32 0 
+5 Constant 6 7 72 0 
+5 Constant 6 11 1000 0 
+5 Constant 6 23 1 0 
+4 Constant 10 34 32 
+2 TypeVoid 3 
+2 TypeBool 5 
+4 TypeArray 8 5 7 
+3 TypeStruct 4 8 
 
-4 TypePointer 9 7 4
-4 TypeArray 12 10 11
-4 TypePointer 13 5 12
-5 TypeFunction 14 3 9 13
-3 TypeFloat 20 32
-4 TypePointer 21 8 20
-5 TypeStruct 22 6 6 6
+4 TypePointer 9 7 4 
+4 TypeArray 12 10 11 
+4 TypePointer 13 5 12 
+5 TypeFunction 14 3 9 13 
+3 TypeFloat 20 32 
+4 TypePointer 21 8 20 
+5 TypeStruct 22 6 6 6 
 
-4 TypeArray 24 22 23
-9 TypeStruct 19 21 6 6 6 6 6 24
+4 TypeArray 24 22 23 
+9 TypeStruct 19 21 6 6 6 6 6 24 
 
-4 TypePointer 25 7 19
+4 TypePointer 25 7 19 
 
-5 ExtInst 3 27 2 DebugInfoNone
-7 ExtInst 3 30 2 DebugSource 29 27
+5 ExtInst 3 27 2 DebugInfoNone 
+7 ExtInst 3 30 2 DebugSource 29 27 
 9 ExtInst 3 31 2 DebugCompilationUnit 65536 4 30 21
-7 ExtInst 3 32 2 DebugTypeFunction 0 27
-8 ExtInst 3 35 2 DebugTypeBasic 33 34 3
+7 ExtInst 3 32 2 DebugTypeFunction 0 27 
+8 ExtInst 3 35 2 DebugTypeBasic 33 34 3 
 7 ExtInst 3 36 2 DebugTypeArray 35 11 ; Count = 1000
-8 ExtInst 3 37 2 DebugTypePointer 36 4294967295 0
-16 ExtInst 3 40 2 DebugFunction 38 32 30 25 0 31 39 44 25 27 27
-12 ExtInst 3 42 2 DebugLocalVariable 41 37 30 15 0 40 0
+8 ExtInst 3 37 2 DebugTypePointer 36 4294967295 0 
+16 ExtInst 3 40 2 DebugFunction 38 32 30 25 0 31 39 44 25 27 27 
+12 ExtInst 3 42 2 DebugLocalVariable 41 37 30 15 0 40 0 
 6 ExtInst 3 43 2 DebugTypeTemplate 40
-6 ExtInst 3 44 2 DebugOperation 0
-6 ExtInst 3 45 2 DebugExpression 44
+6 ExtInst 3 44 2 DebugOperation 0 
+6 ExtInst 3 45 2 DebugExpression 44 
 
-5 Function 3 15 2 14
-3 FunctionParameter 9 16
-3 FunctionParameter 13 17
+5 Function 3 15 2 14 
+3 FunctionParameter 9 16 
+3 FunctionParameter 13 17 
 
-2 Label 18
-4 Bitcast 25 26 16
-6 ExtInst 3 46 2 DebugScope 43
-4 Line 29 15 67
-8 ExtInst 3 28 2 DebugValue 42 26 45
-5 ExtInst 3 47 2 DebugNoScope
-1 Return
+2 Label 18 
+4 Bitcast 25 26 16 
+6 ExtInst 3 46 2 DebugScope 43 
+4 Line 29 15 67 
+8 ExtInst 3 28 2 DebugValue 42 26 45 
+5 ExtInst 3 47 2 DebugNoScope 
+1 Return 
 
-1 FunctionEnd
+1 FunctionEnd 
 

--- a/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
+++ b/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-ext=+all --spirv-allow-unknown-intrinsics
 ; RUN: amd-llvm-spirv -r %t.spv -o %t.bc

--- a/test/DebugInfo/Generic/PR20038.ll
+++ b/test/DebugInfo/Generic/PR20038.ll
@@ -1,4 +1,3 @@
-; XFAIL:*
 ; REQUIRES: object-emission
 
 ; For some reason, the output when targetting sparc is not quite as expected.

--- a/test/DebugInfo/Generic/c-and-cpp-mixed.ll
+++ b/test/DebugInfo/Generic/c-and-cpp-mixed.ll
@@ -1,7 +1,6 @@
 ;; This test checks that two DICompileUnits resulted in a link of C and C++
 ;; object files are being translated correctly
 
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv --to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/Generic/dead-argument-order.ll
+++ b/test/DebugInfo/Generic/dead-argument-order.ll
@@ -1,6 +1,5 @@
 ; REQUIRES: object-emission
 
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/Generic/debug-info-eis-option.ll
+++ b/test/DebugInfo/Generic/debug-info-eis-option.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=legacy
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
+++ b/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
@@ -1,7 +1,6 @@
-; XFAIL:*
 ; REQUIRES: object-emission
 ; This test is failing for powerpc64, because a location list for the
-; variable 'c' is not generated at all. Temporary marking this test as XFAIL
+; variable 'c' is not generated at all. Temporary marking this test as XFAIL 
 ; for powerpc, until PR21881 is fixed.
 ; XFAIL: powerpc64
 
@@ -17,14 +16,14 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; This is a test for PR21176.
-; DW_OP_const <const> doesn't describe a constant value, but a value at a constant address.
+; DW_OP_const <const> doesn't describe a constant value, but a value at a constant address. 
 ; The proper way to describe a constant value is DW_OP_constu <const>, DW_OP_stack_value.
 ; For values < 32 we emit the canonical DW_OP_lit<const>.
 
 ; Generated with clang -S -emit-llvm -g -O2 test.cpp
 
 ; extern int func();
-;
+; 
 ; int main()
 ; {
 ;   volatile int c = 13;

--- a/test/DebugInfo/Generic/inline-scopes.ll
+++ b/test/DebugInfo/Generic/inline-scopes.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; REQUIRES: object-emission
 
 ; RUN: llvm-as < %s -o %t.bc

--- a/test/DebugInfo/Generic/inlined-locations.ll
+++ b/test/DebugInfo/Generic/inlined-locations.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT

--- a/test/DebugInfo/Generic/inlined-vars.ll
+++ b/test/DebugInfo/Generic/inlined-vars.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/Generic/linear-dbg-value.ll
+++ b/test/DebugInfo/Generic/linear-dbg-value.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/Generic/missing-abstract-variable.ll
+++ b/test/DebugInfo/Generic/missing-abstract-variable.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; REQUIRES: object-emission
 
 ; RUN: llvm-as < %s -o %t.bc

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv -spirv-text %t.bc -o %t.spt --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv -spirv-text %t.bc -o %t.spt --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayExpr.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayExpr.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ;; The test checks, that Fortran dynamic arrays are being correctly represented
 ;; by SPIR-V debug information
 ;; Unlike 'static' arrays dynamic can have following parameters of

--- a/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayVar.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayVar.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ;; DebugInfo/dwarfdump-dataLocationVar.ll from llvm.org is used as base for this test
 ;; The test checks, that Fortran dynamic arrays are being correctly represented
 ;; by SPIR-V debug information

--- a/test/DebugInfo/OpenCL100/DebugInfoSubrange.ll
+++ b/test/DebugInfo/OpenCL100/DebugInfoSubrange.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv -spirv-text %t.bc -o %t.spt
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/X86/constant-aggregate.ll
+++ b/test/DebugInfo/X86/constant-aggregate.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/constant-loclist.ll
+++ b/test/DebugInfo/X86/constant-loclist.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/convert-debugloc.ll
+++ b/test/DebugInfo/X86/convert-debugloc.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-declare-alloca.ll
+++ b/test/DebugInfo/X86/dbg-declare-alloca.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-declare-arg.ll
+++ b/test/DebugInfo/X86/dbg-declare-arg.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
@@ -18,7 +17,7 @@ target triple = "spir64-unknown-unknown"
 
 ; C++ source:
 ; class A { public: int x; int y; int z; int o; ~A() { x = 1; }};
-;
+; 
 ; A foo(int i) {
 ;   int j = 0;
 ;   if (i == 42) {
@@ -30,7 +29,7 @@ target triple = "spir64-unknown-unknown"
 ; }
 
 ; CHECK: DW_AT_name {{.*}}"j"
-; CHECK: DW_TAG_variable
+; CHECK: DW_TAG_variable  
 ; CHECK-NEXT:   DW_AT_location [DW_FORM_sec_offset] (
 ; CHECK-NEXT:     0x{{.*}}, 0x{{.*}}: DW_OP_breg7 RSP+8, DW_OP_deref)
 ; CHECK-NEXT:   DW_AT_name {{.*}}"my_a"

--- a/test/DebugInfo/X86/dbg-declare.ll
+++ b/test/DebugInfo/X86/dbg-declare.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-value-const-byref.ll
+++ b/test/DebugInfo/X86/dbg-value-const-byref.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-value-frame-index.ll
+++ b/test/DebugInfo/X86/dbg-value-frame-index.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-value-isel.ll
+++ b/test/DebugInfo/X86/dbg-value-isel.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-value-location.ll
+++ b/test/DebugInfo/X86/dbg-value-location.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dbg-value-range.ll
+++ b/test/DebugInfo/X86/dbg-value-range.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/double-declare.ll
+++ b/test/DebugInfo/X86/double-declare.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dw_op_minus_direct.ll
+++ b/test/DebugInfo/X86/dw_op_minus_direct.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; Test dwarf codegen of DW_OP_minus.
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv

--- a/test/DebugInfo/X86/fi-expr.ll
+++ b/test/DebugInfo/X86/fi-expr.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/float_const.ll
+++ b/test/DebugInfo/X86/float_const.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/frame-register.ll
+++ b/test/DebugInfo/X86/frame-register.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/inline-member-function.ll
+++ b/test/DebugInfo/X86/inline-member-function.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; REQUIRES: object-emission
 
 ; RUN: llvm-as < %s -o %t.bc

--- a/test/DebugInfo/X86/inlined-formal-parameter.ll
+++ b/test/DebugInfo/X86/inlined-formal-parameter.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/lexical-block-file-inline.ll
+++ b/test/DebugInfo/X86/lexical-block-file-inline.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
@@ -34,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 ;;    return 0;
 ;;  }
 ;;}
-;;int foo() {
+;;int foo() {  
 ;;  return bar();
 ;;}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/DebugInfo/X86/live-debug-variables.ll
+++ b/test/DebugInfo/X86/live-debug-variables.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/partial-constant.ll
+++ b/test/DebugInfo/X86/partial-constant.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/reference-argument.ll
+++ b/test/DebugInfo/X86/reference-argument.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/single-dbg_value.ll
+++ b/test/DebugInfo/X86/single-dbg_value.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/single-fi.ll
+++ b/test/DebugInfo/X86/single-fi.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/this-stack_value.ll
+++ b/test/DebugInfo/X86/this-stack_value.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
@@ -25,7 +24,7 @@
 ;     A a;
 ;     int b = 48;
 ;   };
-;
+;    
 ;   B *getB() { return new B(); }
 ;
 ; The inlined A::this pointer has the same location as B::this, but it may not be

--- a/test/DebugInfo/X86/union-const.ll
+++ b/test/DebugInfo/X86/union-const.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/expr-opcode.ll
+++ b/test/DebugInfo/expr-opcode.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: amd-llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll

--- a/test/complex-constexpr-vector.ll
+++ b/test/complex-constexpr-vector.ll
@@ -1,4 +1,3 @@
-; XFAIL: *
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: amd-llvm-spirv %t.bc -o %t.spv
 ; RUN: amd-llvm-spirv %t.spv -to-text -o %t.spt


### PR DESCRIPTION
These expressions exist downstream on amd-staging and are necessary for
debugging on device. Fixes SWDEV-445691.