### PR TITLE
[HeterogeneousDwarf] Poison invalid DIExpressions after translation

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1148,6 +1148,8 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   bool IsDefinition = Flags & SPIRVDebug::FlagIsDefinition;
   MDNode *VarDecl = nullptr;
   if (IsDefinition) {
+    if (DIExpr && DIExpr->holdsNewElements() && !DIExpr->isValid())
+      DIExpr = DIExpr->getPoisoned();
     VarDecl = getDIBuilder(DebugInst).createGlobalVariableExpression(
         Parent, Name, LinkageName, File, LineNo, Ty, IsLocal, IsDefinition,
         DIExpr, StaticMemberDecl);
@@ -1646,6 +1648,17 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
   auto GetExpression = [&](SPIRVId Id) -> DIExpression * {
     return transDebugInst<DIExpression>(BM->get<SPIRVExtInst>(Id));
   };
+  auto PoisonInvalidExpr = [&](DIExpression *Expr, DILocalVariable *Var,
+                               Value *Op) {
+    if (!Expr->holdsNewElements())
+      return Expr;
+    DIExpressionEnv Env{Var, Op, BB->getParent()->getParent()->getDataLayout()};
+    // FIXME: The variadic expression handling for dbg.value below is broken,
+    // just poison.
+    if (Expr->getNewNumLocationOperands() > 1 || !Expr->isValid(Env))
+      return Expr->getPoisoned();
+    return Expr;
+  };
   SPIRVWordVec Ops = DebugInst->getArguments();
   switch (DebugInst->getExtOp()) {
   case SPIRVDebug::Scope:
@@ -1667,21 +1680,25 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       auto *AI =
           new AllocaInst(Type::getInt8Ty(M->getContext()),
                          M->getDataLayout().getAllocaAddrSpace(), "tmp", BB);
-      DbgInstPtr DbgDeclare = DIB.insertDeclare(
-          AI, LocalVar.first, GetExpression(Ops[ExpressionIdx]),
-          LocalVar.second, BB);
+      auto *Expr = PoisonInvalidExpr(GetExpression(Ops[ExpressionIdx]),
+                                     LocalVar.first, AI);
+      DbgInstPtr DbgDeclare =
+          DIB.insertDeclare(AI, LocalVar.first, Expr, LocalVar.second, BB);
       AI->eraseFromParent();
       return DbgDeclare;
     }
-    return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,
-                             GetExpression(Ops[ExpressionIdx]), LocalVar.second,
-                             BB);
+
+    Value *Val = GetValue(Ops[VariableIdx]);
+    auto *Expr = PoisonInvalidExpr(GetExpression(Ops[ExpressionIdx]),
+                                   LocalVar.first, Val);
+    return DIB.insertDeclare(Val, LocalVar.first, Expr, LocalVar.second, BB);
   }
   case SPIRVDebug::Value: {
     using namespace SPIRVDebug::Operand::DebugValue;
     auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
     Value *Val = GetValue(Ops[ValueIdx]);
     DIExpression *Expr = GetExpression(Ops[ExpressionIdx]);
+    Expr = PoisonInvalidExpr(Expr, LocalVar.first, Val);
     DbgInstPtr DbgValIntr = getDIBuilder(DebugInst).insertDbgValueIntrinsic(
         Val, LocalVar.first, Expr, LocalVar.second, BB);
 

--- a/test/DebugInfo/AMDGPU/diop-ops.ll
+++ b/test/DebugInfo/AMDGPU/diop-ops.ll
@@ -6,12 +6,16 @@
 
 ; CHECK: %struct.OnlyInExpr = type { ptr addrspace(5) }
 ; CHECK: !DIExpression(DIOpArg(0, %struct.OnlyInExpr), DIOpConvert(i32))
-; CHECK: !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 10), DIOpAnd())
-; CHECK: !DIExpression(DIOpArg(0, i64), DIOpFragment(11, 12))
-; CHECK: !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 13), DIOpBitOffset(i64))
-; CHECK: !DIExpression(DIOpArg(0, i64), DIOpPushLane(i64), DIOpByteOffset(i64))
+; CHECK: !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpConvert(i32), DIOpConstant(i32 10), DIOpAnd())
+; CHECK: !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpFragment(11, 12))
+; CHECK: !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpConstant(i64 13), DIOpBitOffset(i32))
+; CHECK: !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpPushLane(i64), DIOpByteOffset(i64))
 ; CHECK: !DIExpression(DIOpArg(0, i8), DIOpSExt(i64))
 ; CHECK: !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 15), DIOpComposite(2, i64))
+; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
+; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
+; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
+; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
 ; CHECK: !DIExpression(DW_OP_LLVM_poisoned)
 
 target triple = "spirv64-amd-amdhsa"
@@ -22,13 +26,18 @@ define hidden spir_kernel void @_Z6kernelv() addrspace(4) !dbg !11 !max_work_gro
   %1 = alloca i32, align 4
   %2 = addrspacecast ptr %1 to ptr addrspace(4)
     #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, %struct.OnlyInExpr), DIOpConvert(i32)), !18)
-    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 10), DIOpAnd()), !18)
-    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpFragment(11, 12)), !18)
-    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpConstant(i64 13), DIOpBitOffset(i64)), !18)
-    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpPushLane(i64), DIOpByteOffset(i64)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpConvert(i32), DIOpConstant(i32 10), DIOpAnd()), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpFragment(11, 12)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpConstant(i64 13), DIOpBitOffset(i32)), !18)
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpPushLane(i64), DIOpByteOffset(i64)), !18)
     #dbg_declare(i8 -1, !15, !DIExpression(DIOpArg(0, i8), DIOpSExt(i64)), !18)
     #dbg_declare(i32 14, !15, !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 15), DIOpComposite(2, i64)), !18)
     #dbg_declare(i32 14, !15, !DIExpression(DW_OP_LLVM_poisoned), !18)
+    ; Next four should be poisoned after converting to addrspace(5) since they are invalid.
+    #dbg_declare(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpReinterpret(i64), DIOpConvert(i32)), !18)
+    #dbg_value(ptr %1, !15, !DIExpression(DIOpArg(0, ptr), DIOpReinterpret(i64), DIOpConvert(i32)), !18)
+    #dbg_value(ptr %1, !15, !DIExpression(DIOpArg(0, i64), DIOpConvert(i32)), !18)
+    #dbg_value(!DIArgList(i32 1, i32 2), !15, !DIExpression(DIOpArg(0, i32), DIOpArg(1, i32), DIOpAdd()), !18)
   store i32 43, ptr addrspace(4) %2, align 4, !dbg !18
   ret void, !dbg !18
 }


### PR DESCRIPTION
Some of the type transformations (e.g. pointer addrspace) can result in invalid expressions.