### PR TITLE
Fix issues with device-side malloc uses

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1108,6 +1108,8 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
            Dst->getPointerAddressSpace()) &&
           M->getTargetTriple().getVendor() == Triple::VendorType::AMD)
         CO = Instruction::AddrSpaceCast;
+    } else if (Src->getType() == Dst) { // Spuriously inserted BC
+      return Src;
     } else {
       // OpBitcast need to be handled as a special-case when the source is a
       // pointer and the destination is not a pointer, and where the source is not
@@ -3500,6 +3502,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
     F->setName("old_" + Name);
     auto *NewFn = Function::Create(NewFT, F->getLinkage(), F->getAddressSpace(),
                                    Name, F->getParent());
+    F->replaceAllUsesWith(NewFn);
     mapFunction(BF, NewFn);
     return NewFn;
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -769,9 +769,7 @@ SPIRVType *LLVMToSPIRVBase::transPointerType(SPIRVType *ET, unsigned AddrSpc) {
       !BM->shouldEmitFunctionPtrAddrSpace())
     return transPointerType(ET, SPIRAS_Private);
   if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_untyped_pointers) &&
-      !(ET->isTypeArray() || ET->isTypeVector() || ET->isSPIRVOpaqueType() ||
-        (M->getTargetTriple().getVendor() == Triple::VendorType::AMD &&
-         ET->getOpCode() == OpTypeFunction))) {
+      !(ET->isTypeArray() || ET->isTypeVector() || ET->isSPIRVOpaqueType())) {
     TranslatedTy = BM->addPointerType(
         SPIRSPIRVAddrSpaceMap::map(static_cast<SPIRAddressSpace>(AddrSpc)),
         nullptr);
@@ -2104,8 +2102,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
           }
         }
       }
-      if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_untyped_pointers) &&
-          !Init->getType()->isArrayTy()) {
+      if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_untyped_pointers)) {
         BVarInit = transConstantUse(Init, transType(Init->getType()));
       } else {
         SPIRVType *TransTy = transType(Ty);


### PR DESCRIPTION
Stop using typed pointers for functions; avoid hung uses of `old_umul`; do not insert spurious bitcasts.