### PR TITLE
[NFC] Replace DenseMap with switch and fix build issues.

### DIFF
--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -38,7 +38,6 @@
 
 #include "OCLUtil.h"
 #include "SPIRVToOCL.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/Verifier.h"
 
 #define DEBUG_TYPE "spvtocl20"
@@ -116,27 +115,46 @@ static void translateSPIRVCmpXchgToLLVM(CallInst *CI, Op OC) {
   CI->eraseFromParent();
 }
 
+static AtomicRMWInst::BinOp getAtomicRMWInstForOp(Op op) {
+  switch (op) {
+  case OpAtomicAnd:
+    return AtomicRMWInst::And;
+  case OpAtomicExchange:
+    return AtomicRMWInst::Xchg;
+  case OpAtomicFAddEXT:
+    return AtomicRMWInst::FAdd;
+  case OpAtomicFMaxEXT:
+    return AtomicRMWInst::FMax;
+  case OpAtomicFMinEXT:
+    return AtomicRMWInst::FMin;
+  case OpAtomicIAdd:
+    return AtomicRMWInst::Add;
+  case OpAtomicIDecrement:
+    return AtomicRMWInst::UDecWrap;
+  case OpAtomicIIncrement:
+    return AtomicRMWInst::UIncWrap;
+  case OpAtomicISub:
+    return AtomicRMWInst::Sub;
+  case OpAtomicOr:
+    return AtomicRMWInst::Or;
+  case OpAtomicSMax:
+    return AtomicRMWInst::Max;
+  case OpAtomicSMin:
+    return AtomicRMWInst::Min;
+  case OpAtomicUMax:
+    return AtomicRMWInst::UMax;
+  case OpAtomicUMin:
+    return AtomicRMWInst::UMin;
+  case OpAtomicXor:
+    return AtomicRMWInst::Xor;
+  default:
+    llvm_unreachable("Undefined operation");
+  }
+}
+
 static void translateSPIRVAtomicBuiltinToLLVMAtomicOp(CallInst *CI, Op OC) {
   if (OC == OpAtomicCompareExchange || OC == OpAtomicCompareExchangeWeak)
     return translateSPIRVCmpXchgToLLVM(CI, OC);
-
-  static const DenseMap<Op, AtomicRMWInst::BinOp> SPIRVtoLLVM{
-    {OpAtomicAnd, AtomicRMWInst::And},
-    {OpAtomicExchange, AtomicRMWInst::Xchg},
-    {OpAtomicFAddEXT, AtomicRMWInst::FAdd},
-    {OpAtomicFMaxEXT, AtomicRMWInst::FMax},
-    {OpAtomicFMinEXT, AtomicRMWInst::FMin},
-    {OpAtomicIAdd, AtomicRMWInst::Add},
-    {OpAtomicIDecrement, AtomicRMWInst::UDecWrap},
-    {OpAtomicIIncrement, AtomicRMWInst::UIncWrap},
-    {OpAtomicISub, AtomicRMWInst::Sub},
-    {OpAtomicOr, AtomicRMWInst::Or},
-    {OpAtomicSMax, AtomicRMWInst::Max},
-    {OpAtomicSMin, AtomicRMWInst::Min},
-    {OpAtomicUMax, AtomicRMWInst::UMax},
-    {OpAtomicUMin, AtomicRMWInst::UMin},
-    {OpAtomicXor, AtomicRMWInst::Xor}
-  };
 
   assert(isa<ConstantInt>(CI->getArgOperand(CI->arg_size() - 1)));
   assert(isa<ConstantInt>(CI->getArgOperand(CI->arg_size() - 2)));
@@ -156,8 +174,9 @@ static void translateSPIRVAtomicBuiltinToLLVMAtomicOp(CallInst *CI, Op OC) {
     ST->setAtomic(Order, S);
     CI->replaceAllUsesWith(ST);
   } else {
-    auto RMW = Builder.CreateAtomicRMW(SPIRVtoLLVM.at(OC), CI->getOperand(0),
-                                       CI->getOperand(1), {}, Order, S);
+    auto RMW =
+        Builder.CreateAtomicRMW(getAtomicRMWInstForOp(OC), CI->getOperand(0),
+                                CI->getOperand(1), {}, Order, S);
     CI->replaceAllUsesWith(RMW);
   }
 


### PR DESCRIPTION
This PR fixes the following build error caused by the `DenseMap` and the `Op` enum that is used as key. `DenseMap` fails to find a value for `EmptyKey` and `TombstoneKey`. This fix replaces the `DenseMap` with a simpler switch lookup.

```
[  2%] Building CXX object lib/SPIRV/CMakeFiles/LLVMSPIRVAMDLib.dir/SPIRVToOCL20.cpp.o
In file included from /home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/SPIRVToOCL20.cpp:39:
In file included from /home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/OCLUtil.h:42:
In file included from /home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/SPIRVInternal.h:43:
In file included from /home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/libSPIRV/SPIRVEnum.h:43:
In file included from /home/macarras/spirv/SPIRV-LLVM-Translator/include/LLVMSPIRVOpts.h:42:
In file included from /home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/SmallVector.h:17:
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:223:20: error: constexpr variable 'V' must be initialized by a constant expression
  223 |     constexpr Enum V = static_cast<Enum>(Info::getEmptyKey());
      |                    ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:451:22: note: in instantiation of member function 'llvm::DenseMapInfo<spv::Op>::getEmptyKey' requested here
  451 |     return KeyInfoT::getEmptyKey();
      |                      ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:374:27: note: in instantiation of member function 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::getEmptyKey' requested here
  374 |     const KeyT EmptyKey = getEmptyKey();
      |                           ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:852:20: note: in instantiation of member function 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::initEmpty' requested here
  852 |       this->BaseT::initEmpty();
      |                    ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:731:5: note: in instantiation of member function 'llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>::init' requested here
  731 |     init(std::distance(I, E));
      |     ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:740:9: note: in instantiation of function template specialization 'llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>::DenseMap<const llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp> *>' requested here
  740 |       : DenseMap(Vals.begin(), Vals.end()) {}
      |         ^
/home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/SPIRVToOCL20.cpp:123:51: note: in instantiation of member function 'llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>::DenseMap' requested here
  123 |   static const DenseMap<Op, AtomicRMWInst::BinOp> SPIRVtoLLVM{
      |                                                   ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:223:24: note: integer value 4294967295 is outside the valid range of values [0, 2147483647] for the enumeration type 'Op'
  223 |     constexpr Enum V = static_cast<Enum>(Info::getEmptyKey());
      |                        ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:228:20: error: constexpr variable 'V' must be initialized by a constant expression
  228 |     constexpr Enum V = static_cast<Enum>(Info::getTombstoneKey());
      |                    ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:454:58: note: in instantiation of member function 'llvm::DenseMapInfo<spv::Op>::getTombstoneKey' requested here
  454 |   static const KeyT getTombstoneKey() { return KeyInfoT::getTombstoneKey(); }
      |                                                          ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:616:31: note: in instantiation of member function 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::getTombstoneKey' requested here
  616 |     const KeyT TombstoneKey = getTombstoneKey();
      |                               ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:466:9: note: in instantiation of function template specialization 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::LookupBucketFor<spv::Op>' requested here
  466 |     if (LookupBucketFor(Key, TheBucket))
      |         ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:478:31: note: in instantiation of function template specialization 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::lookupOrInsertIntoBucket<const spv::Op &, const llvm::AtomicRMWInst::BinOp &>' requested here
  478 |     auto [Bucket, Inserted] = lookupOrInsertIntoBucket(
      |                               ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:223:12: note: in instantiation of function template specialization 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::try_emplace_impl<const spv::Op &, const llvm::AtomicRMWInst::BinOp &>' requested here
  223 |     return try_emplace_impl(KV.first, KV.second);
      |            ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:271:7: note: in instantiation of member function 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::insert' requested here
  271 |       insert(*I);
      |       ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:732:11: note: in instantiation of function template specialization 'llvm::DenseMapBase<llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>, spv::Op, llvm::AtomicRMWInst::BinOp, llvm::DenseMapInfo<spv::Op>, llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp>>::insert<const llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp> *>' requested here
  732 |     this->insert(I, E);
      |           ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMap.h:740:9: note: in instantiation of function template specialization 'llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>::DenseMap<const llvm::detail::DenseMapPair<spv::Op, llvm::AtomicRMWInst::BinOp> *>' requested here
  740 |       : DenseMap(Vals.begin(), Vals.end()) {}
      |         ^
/home/macarras/spirv/SPIRV-LLVM-Translator/lib/SPIRV/SPIRVToOCL20.cpp:123:51: note: in instantiation of member function 'llvm::DenseMap<spv::Op, llvm::AtomicRMWInst::BinOp>::DenseMap' requested here
  123 |   static const DenseMap<Op, AtomicRMWInst::BinOp> SPIRVtoLLVM{
      |                                                   ^
/home/macarras/spirv/llvm-project/llvm/include/llvm/ADT/DenseMapInfo.h:228:24: note: integer value 4294967294 is outside the valid range of values [0, 2147483647] for the enumeration type 'Op'
  228 |     constexpr Enum V = static_cast<Enum>(Info::getTombstoneKey());
      |                        ^
2 errors generated.
```