### PR TITLE
[SPIRv][passes] move PassPlugin.h tp Extensions

### DIFF
--- a/lib/SPIRV/PassPlugin.cpp
+++ b/lib/SPIRV/PassPlugin.cpp
@@ -49,7 +49,7 @@
 #include "SPIRVWriter.h"
 
 #include "llvm/Passes/PassBuilder.h"
-#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Extensions/PassPlugin.h"
 
 using namespace llvm;
 

--- a/lib/SPIRV/PassPlugin.cpp
+++ b/lib/SPIRV/PassPlugin.cpp
@@ -49,7 +49,7 @@
 #include "SPIRVWriter.h"
 
 #include "llvm/Passes/PassBuilder.h"
-#include "llvm/Extensions/PassPlugin.h"
+#include "llvm/Plugins/PassPlugin.h"
 
 using namespace llvm;
 


### PR DESCRIPTION
 
catch up to llvm change: 
commit d87b47d3a893b849cfd1ee5309b9fec2b0aec8cd
Author: Alexis Engelke <engelke@in.tum.de>
Date:   Mon Dec 22 11:42:27 2025 +0100

    [LLVM][NFC] Move PassPlugin from Passes to Extensions lib
