### PR TITLE
Filter out target-features from "NonSemantic.AuxData"

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -5814,6 +5814,10 @@ void SPIRVToLLVM::transAuxDataInst(SPIRVExtInst *BC) {
   case NonSemanticAuxData::FunctionAttribute:
   case NonSemanticAuxData::GlobalVariableAttribute: {
     assert(Args.size() < 4 && "Unexpected FunctionAttribute Args");
+    // Skip target-specific attributes so they won't conflict with attributes
+    // that can be set later during compilation.
+    if (AttrOrMDName == "target-features" || AttrOrMDName == "target-cpu")
+      return;
     // If this attr was specially handled and added elsewhere, skip it.
     Attribute::AttrKind AsKind = Attribute::getAttrKindFromName(AttrOrMDName);
     if (AsKind != Attribute::None)

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/filter-target-attrs.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/filter-target-attrs.ll
@@ -1,0 +1,37 @@
+; RUN: llvm-spirv %s -spirv-text --spirv-preserve-auxdata -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %s -o %t.spv --spirv-preserve-auxdata
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Test that target-features and target-cpu function attributes are preserved
+; in SPIR-V but filtered out when reading back to LLVM IR.
+
+; CHECK-SPIRV: ExtInstImport [[#Import:]] "NonSemantic.AuxData"
+
+; CHECK-SPIRV-DAG: String [[#TargetCPU:]] "target-cpu"
+; CHECK-SPIRV-DAG: String [[#TargetCPUVal:]] "generic"
+; CHECK-SPIRV-DAG: String [[#TargetFeatures:]] "target-features"
+; CHECK-SPIRV-DAG: String [[#TargetFeaturesVal:]] "+avx2"
+; CHECK-SPIRV-DAG: String [[#CustomAttr:]] "custom-attr"
+; CHECK-SPIRV-DAG: String [[#CustomAttrVal:]] "custom-value"
+
+; CHECK-SPIRV: Name [[#Func:]] "test_func"
+
+; CHECK-SPIRV-DAG: ExtInst {{.*}} [[#Import]] NonSemanticAuxDataFunctionAttribute [[#Func]] [[#TargetCPU]] [[#TargetCPUVal]]
+; CHECK-SPIRV-DAG: ExtInst {{.*}} [[#Import]] NonSemanticAuxDataFunctionAttribute [[#Func]] [[#TargetFeatures]] [[#TargetFeaturesVal]]
+; CHECK-SPIRV-DAG: ExtInst {{.*}} [[#Import]] NonSemanticAuxDataFunctionAttribute [[#Func]] [[#CustomAttr]] [[#CustomAttrVal]]
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-LLVM: define spir_func void @test_func() #[[#FuncAttr:]]
+define spir_func void @test_func() #0 {
+entry:
+  ret void
+}
+
+; CHECK-LLVM: attributes #[[#FuncAttr]] =
+; CHECK-LLVM-SAME: "custom-attr"="custom-value"
+; CHECK-LLVM-NOT: target-cpu
+; CHECK-LLVM-NOT: target-features
+
+attributes #0 = { "target-cpu"="generic" "target-features"="+avx2" "custom-attr"="custom-value" }


### PR DESCRIPTION
This is required to avoid conflicts in later stages of compilation.


