### PR TITLE
Follow up "Unify unsized array handling for AMGCN flavoured SPIR-V"

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -358,7 +358,8 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     // and evaluated before the LLVM ArrayType can be constructed.
     auto *LenExpr = static_cast<const SPIRVTypeArray *>(T)->getLength();
     auto *LenValue = cast<ConstantInt>(transValue(LenExpr, nullptr, nullptr));
-    if (LenValue->getZExtValue() == UINT32_MAX && IsAMDGCN)
+    if ((LenValue->getZExtValue() == UINT64_MAX ||
+         LenValue->getZExtValue() == UINT32_MAX) && IsAMDGCN)
       return mapType(T, ArrayType::get(transType(T->getArrayElementType()), 0));
     return mapType(T, ArrayType::get(transType(T->getArrayElementType()),
                                      LenValue->getZExtValue()));

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -358,8 +358,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     // and evaluated before the LLVM ArrayType can be constructed.
     auto *LenExpr = static_cast<const SPIRVTypeArray *>(T)->getLength();
     auto *LenValue = cast<ConstantInt>(transValue(LenExpr, nullptr, nullptr));
-    if ((LenValue->getZExtValue() == UINT64_MAX ||
-         LenValue->getZExtValue() == UINT32_MAX) && IsAMDGCN)
+    if (LenValue->getZExtValue() == UINT64_MAX && IsAMDGCN)
       return mapType(T, ArrayType::get(transType(T->getArrayElementType()), 0));
     return mapType(T, ArrayType::get(transType(T->getArrayElementType()),
                                      LenValue->getZExtValue()));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -457,7 +457,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     const auto ArraySize =
         T->getArrayNumElements() ? T->getArrayNumElements() :
             (M->getTargetTriple().getVendor() == Triple::VendorType::AMD
-              ? UINT32_MAX : 1);
+              ? UINT64_MAX : 1);
 
     Type *ElTy = T->getArrayElementType();
     SPIRVType *TransType = BM->addArrayType(


### PR DESCRIPTION
SPIR-V backend uses 64bit size to specify zero-lenght arrays for amdgcn.


