### PR TITLE
Force external linkage for HostAccessINTEL GV

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1756,6 +1756,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto *Ty = transType(PreTransTy);
     bool IsConst = BVar->isConstant();
     llvm::GlobalValue::LinkageTypes LinkageTy = transLinkageType(BVar);
+    // HostAccessINTEL implies the symbol must be findable by the host runtime
+    // (hipGetSymbolAddress), so it mustn't have internal linkage.
+    if (M->getTargetTriple().isAMDGCN() &&
+        BVar->hasDecorate(DecorationHostAccessINTEL) &&
+        LinkageTy == GlobalValue::InternalLinkage) {
+      LinkageTy = GlobalValue::ExternalLinkage;
+    }
     SPIRVStorageClassKind BS = BVar->getStorageClass();
     SPIRVValue *Init = BVar->getInitializer();
 


### PR DESCRIPTION
Reasoning for the fix:
1. it just makes sense :-)
2. SPIR-V backend lowers hidden global definitions as globals with no (private) linkage type screwing up GV detectability by `hipGetSymbolAddress`. While I'm thinking of changing it - I'm not yet convinced, that hidden definitions with external linkage type should be lowered to SPIR-V to GVs with Export linkage type. Such change probably makes sense when we have an assumption, that SPIR-V will be converted back to LLVM IR, but seem to be very wrong when linking is done on SPIR-V level.

Alternatives:
1. actually introduce hidden visibility to SPIR-V, so we could separate linkage type and visibility concepts like LLVM does (long term good approach);
2. add a W/A directly in the backend, checking, if triple is AMDGCN, then we know, that SPIR-V will be converted back to LLVM IR hence emit Export linkage type.

Why not put this W/A directly into KhronosGroup/SPIRV-LLVM-Translator? Well, it would cause some uncomfortable questions that I'm not ready to answer, like: is it SPIR-V consumers problem, that HostAccessINTEL GV was generated with no Linkage Type? Note, SPIR-V translator doesn't even check for visibility, so hidden external GV with definition always translates to Export.


