### PR TITLE
Fix return type for AMDGCN intrinsics returning constant address space pointers

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -854,11 +854,11 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
                                    SPIRVEC_UnsupportedVarArgFunction);
 
     SPIRVType *RT = transType(FnTy->getReturnType());
-    if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD &&
-        F->isIntrinsic() && F->getReturnType()->isPointerTy() &&
-        F->getReturnType()->getPointerAddressSpace() ==
-            AMDGPUAS::CONSTANT_ADDRESS)
-      RT = transType(PointerType::get(F->getContext(), SPIRAS_Constant));
+    if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD)
+      if (Type *ReturnType = F->getReturnType();
+          ReturnType->isPtrOrPtrVectorTy())
+        RT = transType(ReturnType->getWithNewType(
+            PointerType::get(F->getContext(), SPIRAS_Constant)));
 
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -84,6 +84,7 @@
 #include "llvm/IR/TypedPointerType.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/AMDGPUAddrSpace.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -854,7 +855,9 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
 
     SPIRVType *RT = transType(FnTy->getReturnType());
     if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD &&
-        F->hasName() && F->getName().contains("dispatch.ptr"))
+        F->isIntrinsic() && F->getReturnType()->isPointerTy() &&
+        F->getReturnType()->getPointerAddressSpace() ==
+            AMDGPUAS::CONSTANT_ADDRESS)
       RT = transType(PointerType::get(F->getContext(), SPIRAS_Constant));
 
     std::vector<SPIRVType *> PT;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -456,9 +456,11 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     // SPIR-V 1.3 s3.32.6: Length is the number of elements in the array.
     //                     It must be at least 1.
     const auto ArraySize =
-        T->getArrayNumElements() ? T->getArrayNumElements() :
-            (M->getTargetTriple().getVendor() == Triple::VendorType::AMD
-              ? UINT64_MAX : 1);
+        T->getArrayNumElements()
+            ? T->getArrayNumElements()
+            : (M->getTargetTriple().getVendor() == Triple::VendorType::AMD
+                   ? UINT64_MAX
+                   : 1);
 
     Type *ElTy = T->getArrayElementType();
     SPIRVType *TransType = BM->addArrayType(
@@ -855,9 +857,8 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
 
     SPIRVType *RT = transType(FnTy->getReturnType());
     if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD)
-      if (Type *ReturnType = F->getReturnType();
-          ReturnType->isPtrOrPtrVectorTy())
-        RT = transType(ReturnType->getWithNewType(
+      if (F->getReturnType()->isPtrOrPtrVectorTy())
+        RT = transType(F->getReturnType()->getWithNewType(
             PointerType::get(F->getContext(), SPIRAS_Constant)));
 
     std::vector<SPIRVType *> PT;
@@ -1607,8 +1608,7 @@ SPIRVInstruction *LLVMToSPIRVBase::transBinaryInst(BinaryOperator *B,
 SPIRVInstruction *LLVMToSPIRVBase::transCmpInst(CmpInst *Cmp,
                                                 SPIRVBasicBlock *BB) {
   auto *Op0 = Cmp->getOperand(0);
-  SPIRVValue *TOp0 =
-      transValue(Op0, BB, true, FuncTransMode::Pointer);
+  SPIRVValue *TOp0 = transValue(Op0, BB, true, FuncTransMode::Pointer);
   SPIRVValue *TOp1 =
       transValue(Cmp->getOperand(1), BB, true, FuncTransMode::Pointer);
   if (Op0->getType()->isPointerTy()) {
@@ -2414,9 +2414,9 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   if (AllocaInst *Alc = dyn_cast<AllocaInst>(V)) {
     SPIRVType *TranslatedTy =
         M->getTargetTriple().getVendor() != Triple::VendorType::AMD
-          ? transScavengedType(V)
-          : BM->addPointerType(StorageClassFunction,
-                               transType(Alc->getAllocatedType()));
+            ? transScavengedType(V)
+            : BM->addPointerType(StorageClassFunction,
+                                 transType(Alc->getAllocatedType()));
     if (Alc->isArrayAllocation()) {
       SPIRVValue *Length = transValue(Alc->getArraySize(), BB);
       assert(Length && "Couldn't translate array size!");
@@ -2773,8 +2773,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       auto WrapV = Ops.back();
       Ops.pop_back();
       auto IncDec = mapValue(V, BM->addInstTemplate(OC, Ops, BB, Ty));
-      IncDec->addDecorate(new SPIRVDecorate(DecorationMaxByteOffsetId, IncDec,
-                                            WrapV));
+      IncDec->addDecorate(
+          new SPIRVDecorate(DecorationMaxByteOffsetId, IncDec, WrapV));
       return IncDec;
       // TODO: figure out handling of saturating val.
     } else
@@ -4485,7 +4485,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     SPIRVType *IntegralTy = transType(II->getType()->getStructElementType(1));
     // IntegralTy is the type of the result. We want to create a pointer to this
     // that we can pass to OpenCLLIB::modf to store the integral part.
-    SPIRVType *GenericPtrTy = BM->addPointerType(StorageClassFunction, IntegralTy);
+    SPIRVType *GenericPtrTy =
+        BM->addPointerType(StorageClassFunction, IntegralTy);
     auto *IntegralPtrTy = dyn_cast<SPIRVTypePointer>(GenericPtrTy);
     // We need to use the entry BB of the function calling llvm.modf.*, instead
     // of the current BB. For that, we'll find current BB's parent and get its

--- a/test/llvm-intrinsics/amdgcn-intrinsic-addrspace.ll
+++ b/test/llvm-intrinsics/amdgcn-intrinsic-addrspace.ll
@@ -7,8 +7,7 @@
 ; but when round-tripped through SPIR-V, the reader reconstructs them with
 ; addrspace(0) unless it uses LLVM's canonical intrinsic declaration.
 
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -spirv-allow-unknown-intrinsics=llvm.amdgcn %t.bc -o %t.spv
+; RUN: llvm-spirv -spirv-allow-unknown-intrinsics=llvm.amdgcn %s -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s
 
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"

--- a/test/llvm-intrinsics/amdgcn-intrinsic-addrspace.ll
+++ b/test/llvm-intrinsics/amdgcn-intrinsic-addrspace.ll
@@ -1,0 +1,38 @@
+; Test that non-overloaded AMDGCN intrinsics returning pointers with specific
+; address spaces are correctly round-tripped through SPIR-V.
+;
+; SPIR-V represents all pointer types using storage classes, and the Generic
+; storage class maps to addrspace(0) in LLVM. Intrinsics like
+; llvm.amdgcn.implicitarg.ptr canonically return ptr addrspace(4) (Constant),
+; but when round-tripped through SPIR-V, the reader reconstructs them with
+; addrspace(0) unless it uses LLVM's canonical intrinsic declaration.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -spirv-allow-unknown-intrinsics=llvm.amdgcn %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s
+
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128-p9:192:256:256:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9"
+target triple = "spirv64-amd-amdhsa"
+
+; CHECK-DAG: declare {{.*}} ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; CHECK-DAG: declare {{.*}} ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+; CHECK-DAG: declare {{.*}} ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+; CHECK-DAG: declare {{.*}} ptr addrspace(4) @llvm.amdgcn.queue.ptr()
+
+define void @test_amdgcn_ptr_intrinsics(ptr addrspace(1) %out) {
+entry:
+; CHECK: %implicitarg = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %implicitarg = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; CHECK: %dispatch = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+  %dispatch = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+; CHECK: %kernarg = call ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+  %kernarg = call ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+; CHECK: %queue = call ptr addrspace(4) @llvm.amdgcn.queue.ptr()
+  %queue = call ptr addrspace(4) @llvm.amdgcn.queue.ptr()
+  ret void
+}
+
+declare ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+declare ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
+declare ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
+declare ptr addrspace(4) @llvm.amdgcn.queue.ptr()


### PR DESCRIPTION
The previous check only matched `dispatch.ptr` by name

Fixes LCOMPILER-1667 