### PR TITLE
Use PAT instead of GITHUB_TOKEN for upstream merge workflow

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: amd-staging
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure git
         run: |
@@ -88,7 +88,7 @@ jobs:
         id: create-pr
         if: steps.merge.outputs.conflict == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           PR_URL=$(gh pr create \
             --base amd-staging \


### PR DESCRIPTION
Seems like GITHUB_TOKEN is blocked from creating PRs, possibly by org-level restrictions. Switch to a Personal Access Token stored as PAT_TOKEN secret to bypass this limitation.