### PR TITLE
Add merge commit warning to upstream merge PR description

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -98,6 +98,10 @@ jobs:
             --body "$(cat <<'EOF'
           Automated merge of upstream KhronosGroup/SPIRV-LLVM-Translator main branch.
 
+          **Merge this PR using "Create a merge commit" — do NOT squash.**
+          Squash-merging destroys upstream ancestry tracking and will cause
+          conflicts on every future merge.
+
           This PR was created automatically by the upstream-merge workflow.
           EOF
           )")


### PR DESCRIPTION
## Summary

Adds a bold warning to the auto-generated upstream merge PR body reminding reviewers to use "Create a merge commit" instead of squash merge. Squash-merging destroys upstream ancestry tracking and causes conflicts on every future merge.