### PR TITLE
Enable SPIR-V Backend integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,9 @@ endif()
 
 is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
 if(spirv_present_result)
-  message(STATUS "Found SPIR-V Backend, but it is currently disabled for AMD's fork.")
-  # set(SPIRV_BACKEND_FOUND TRUE)
-  # add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+  message(STATUS "Found SPIR-V Backend")
+  set(SPIRV_BACKEND_FOUND TRUE)
+  add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
 endif()
 
 set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
## Summary

Sets `SPIRV_BACKEND_FOUND` and defines `LLVM_SPIRV_BACKEND_TARGET_PRESENT` when the in-tree LLVM SPIRV target is detected.

Without this, building `amd-llvm-spirv` against an LLVM that includes the SPIRV backend in `LLVM_TARGETS_TO_BUILD` aborts at startup:

```
CommandLine Error: Option 'spirv-ext' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

The guarded block in `tools/llvm-spirv/llvm-spirv.cpp` renames the backend's `spirv-ext` `cl::opt` before the translator registers its own, resolving the collision.

## Context

Hit while enabling the SPIRV target in TheRock (ROCm/TheRock#4689).