### PR TITLE
Correctly reverse translate GEP coming from `G_PTR_ADD`

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2598,6 +2598,18 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         if (auto GV =
               dyn_cast<GlobalValue>(CE->getOperand(0)->stripPointerCasts()))
           BaseTy = GV->getValueType();
+      if (Index.size() == 2 &&
+          !GetElementPtrInst::getIndexedType(BaseTy, Index)) {
+        // This might've come from a G_PTR_ADD, but because we've retrieved the
+        // full structured type we have to form the correct GEP.
+        Type *ElemTy = BaseTy;
+        APInt Residual = cast<ConstantInt>(Index[1])->getValue();
+        Index.clear();
+        llvm::transform(
+          M->getDataLayout().getGEPIndicesForOffset(ElemTy, Residual),
+          std::back_inserter(Index),
+          [this](auto &&Idx) { return ConstantInt::get(*Context, Idx); });
+      }
       V = ConstantExpr::getGetElementPtr(BaseTy, CT, Index, IsInbound);
     }
     return mapValue(BV, V);


### PR DESCRIPTION
When using the BE, `ConstantExpr` GEPs can get flattened into a G_PTR_ADD, which then gets lowered into an `OpPtrAccessChain`. When we reverse translate, we have access to the full type, which might not be flat / for which the flat index as computed for a G_PTR_ADD might be incorrect. This patch recomputes the index vector based on type and offset for such cases.
