### PR TITLE
Bug fixes and performance improvements

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -6258,9 +6258,11 @@ SPIRVToLLVM::transLinkageType(const SPIRVValue *V) {
       if (static_cast<const SPIRVVariable *>(V)->getStorageClass() ==
           StorageClassWorkgroup &&
           (!V->getType()->isTypeArray() ||
-           V->getType()->getArrayLength() != UINT32_MAX))
+           (V->getType()->getArrayLength() != UINT32_MAX &&
+            V->getType()->getArrayLength() != UINT64_MAX)))
         return GlobalValue::InternalLinkage;
-      if (static_cast<const SPIRVVariable *>(V)->getInitializer() == 0)
+      if (!static_cast<const SPIRVVariable *>(V)->getInitializer() &&
+          !static_cast<const SPIRVVariable *>(V)->isConstant())
         // Tentative definition
         return GlobalValue::CommonLinkage;
     }


### PR DESCRIPTION
This patch handles two issues:

1. Checks `UINT64_MAX` as a marker value for `extern __shared__` / unsized arrays when determining linkage;
2. Ensures we do not set common linkage for `constant`s, as that is illegal.