### PR TITLE
Migrate upstream-merge workflow from PAT to GitHub App

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -18,12 +18,19 @@ jobs:
   merge-upstream:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: amd-staging
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |
@@ -88,7 +95,7 @@ jobs:
         id: create-pr
         if: steps.merge.outputs.conflict == 'false'
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_URL=$(gh pr create \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

Migrate `upstream-merge.yml` from `PAT_TOKEN` (Classic PAT) to a GitHub App.

AMD InfoSec is disabling Classic PATs across all AMD GitHub Orgs. The new \`rocm-spirv-translator-merge\` GitHub App replaces the PAT.

## Required setup before this can land

The repo needs these secrets:
- \`MERGE_APP_ID\` - the App ID
- \`MERGE_APP_PRIVATE_KEY\` - contents of the .pem file

The \`rocm-spirv-translator-merge\` GitHub App must be installed on this repo with:
- Contents: read & write
- Pull requests: read & write
- Workflows: read & write
- Metadata: read

## After this lands

\`PAT_TOKEN\` can be deleted from the repo.