### PR TITLE
upstream-merge: switch to weekdays-only at 08:07 UTC

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -2,8 +2,10 @@ name: Merge Upstream
 
 on:
   schedule:
-    # 7am, 3pm, 11pm EST (12:00, 20:00, 04:00 UTC)
-    - cron: '0 4,12,20 * * *'
+    # Weekdays at 08:07 UTC — ~9am CET / 10am CEST, start-of-day for
+    # Central Europe reviewers. Overnight in the US so PRs are ready to
+    # land first thing. Off-the-hour to avoid cron-fleet pile-ups.
+    - cron: '7 8 * * 1-5'
   workflow_dispatch: # Allow manual triggering
 
 concurrency:


### PR DESCRIPTION
## Summary

Drop the 3x daily upstream merge schedule (04:00 / 12:00 / 20:00 UTC, every day) in favor of a single weekday run at **08:07 UTC**:

- ~9am CET / 10am CEST — start-of-day for Central Europe reviewers
- ~8am GMT / 9am BST — start-of-day UK
- Overnight in the US, so PRs are ready to land first thing

`:07` instead of `:00` to avoid the cron-fleet pile-up at the top of the hour.