### PR TITLE
[CI] Request review from SPIRV merge team on auto-merge PRs

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -104,6 +104,7 @@ jobs:
             --base amd-staging \
             --head ${{ steps.merge.outputs.branch }} \
             --title "${{ steps.merge.outputs.pr_title }}" \
+            --reviewer maarquitos14,MrSidims,AlexVlx,lamb-j,steffenlarsen,mgcarrasco \
             --body "$(cat <<'EOF'
           Automated merge of upstream KhronosGroup/SPIRV-LLVM-Translator main branch.
 


### PR DESCRIPTION
## Summary

Adds `--reviewer` to the `gh pr create` call in the upstream-merge workflow so each automated KhronosGroup → amd-staging merge PR auto-requests review from the SPIRV merge team.

## Reviewers

The flag uses the current `ROCm/spirv-merge-team` membership listed individually:
`maarquitos14, MrSidims, AlexVlx, lamb-j, steffenlarsen, mgcarrasco`

Using individual usernames (rather than `--reviewer ROCm/spirv-merge-team`) avoids requiring the merge GitHub App to hold org-level `Members: read` permission. If team membership changes, the list here needs a manual update — small tradeoff against the org permission ask.

## Effect

Next scheduled run (or manual `workflow_dispatch`) of the upstream-merge workflow will request review from these six users on the merge PR it opens.