### PR TITLE
Skip push-triggered CI jobs in personal forks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   pre-commit:
+    if: ${{ github.repository == 'ROCm/SPIRV-LLVM-Translator' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout TheRock repository

--- a/.github/workflows/rockci-spirv-amd-staging.yml
+++ b/.github/workflows/rockci-spirv-amd-staging.yml
@@ -66,6 +66,7 @@ concurrency:
 
 jobs:
   setup:
+    if: ${{ github.repository == 'ROCm/SPIRV-LLVM-Translator' }}
     uses: ./.github/workflows/setup.yml
     with:
       build_variant: "release"

--- a/.github/workflows/test_aomp_smoke.yml
+++ b/.github/workflows/test_aomp_smoke.yml
@@ -50,6 +50,7 @@ permissions:
 
 jobs:
   aomp_smoke_test:
+    if: ${{ github.repository == 'ROCm/SPIRV-LLVM-Translator' }}
     name: "aomp smoke test"
     runs-on: ${{ inputs.test_runs_on }}
     # Running docker with cap-add and -v /lib/modiles, by recommendation of Github: https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -78,7 +78,7 @@ jobs:
   configure_test_matrix:
     name: "Configure test matrix (${{ inputs.amdgpu_families }})"
     # if there is a test machine available
-    if: ${{ inputs.test_runs_on != '' }}
+    if: ${{ inputs.test_runs_on != '' && github.repository == 'ROCm/SPIRV-LLVM-Translator' }}
     runs-on: ${{ inputs.test_runs_on }}
     outputs:
       sanity_component: ${{ steps.configure.outputs.sanity_component }}

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -44,6 +44,7 @@ permissions:
 
 jobs:
   test_sanity_check:
+    if: ${{ github.repository == 'ROCm/SPIRV-LLVM-Translator' }}
     name: "Sanity ROCM Test (${{ inputs.amdgpu_families }})"
     runs-on: ${{ inputs.test_runs_on }}
     # Running docker with cap-add and -v /lib/modiles, by recommendation of Github: https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html


### PR DESCRIPTION
Rebase of #175 onto current `amd-staging`, opened as a replacement since the original PR is from a fork and could not be updated directly.

Original author: @aobolensk

## Changes vs. #175

- Same `if: ${{ github.repository == 'ROCm/SPIRV-LLVM-Translator' }}` guard on `pre-commit.yml`, `rockci-spirv-amd-staging.yml`, `test_aomp_smoke.yml`, `test_artifacts.yml`, `test_sanity_check.yml`.
- Dropped the change to `.github/workflows/multi_arch_ci.yml` — that file was deleted on `amd-staging` by #177, which split it into `multi_arch_ci_asan.yml` (schedule + workflow_dispatch), `multi_arch_ci_linux.yml` (workflow_call), and `multi_arch_ci_windows.yml` (workflow_call). None of those use `push:` triggers, so no equivalent guard is needed.

Closes #175.