### PR TITLE
[NFC] `applyFPFastMathModeDecorations` doesn't work for calls

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1263,8 +1263,7 @@ static void applyNoIntegerWrapDecorations(const SPIRVValue *BV,
 
 void SPIRVToLLVM::applyFPFastMathModeDecorations(const SPIRVValue *BV,
                                                  Instruction *Inst) {
-  if (!isa<FPMathOperator>(Inst) &&
-      (!M->getTargetTriple().isAMDGCN() || !isa<CallBase>(Inst)))
+  if (!isa<FPMathOperator>(Inst))
     return;
 
   SPIRVWord V{0};


### PR DESCRIPTION
The code being removed was a quick & dirty hack meant to pipe through call site FP Math decorations, but it is not really correct and we should have a more robust mechanism in place in its stead.
