### PR TITLE
[CI test - DO NOT MERGE] Intentionally break two lit tests

### DIFF
--- a/test/transcoding/CommonAddrspaceGlobalVar.ll
+++ b/test/transcoding/CommonAddrspaceGlobalVar.ll
@@ -7,7 +7,7 @@
 ; FIXME: FILECHECK_FAIL during llvm-spirv -r in llc compilation flow
 
 ; CHECK-LLVM-NOT: alloca
-; CHECK-LLVM: @CAG = common addrspace(1) global i32 0, align 4
+; CHECK-LLVM: @DELIBERATE_TEST_FAILURE_TO_VERIFY_CI_BASELINE_DIFF = common addrspace(1) global i32 0, align 4
 ; CHECK-LLVM-NOT: alloca
 
 target triple = "spir64-unknown-unknown"

--- a/test/transcoding/fmax.ll
+++ b/test/transcoding/fmax.ll
@@ -7,7 +7,7 @@
 
 ; Check enabling SPV_KHR_fma does not translate fmax to fma.
 
-; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] fmax [[#]] [[#]]
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DELIBERATE_TEST_FAILURE_TO_VERIFY_CI_BASELINE_DIFF [[#]] [[#]]
 
 ; CHECK-LLVM: %{{.*}} = call spir_func float @_Z4fmaxff(float %{{.*}}, float %{{.*}})
 


### PR DESCRIPTION
## ⚠️ Test PR — do not merge

Filed to verify the new SPIRV CI baseline-diff comment correctly classifies failures into the **🔴 New failures** bucket.

### What this PR does

Modifies two `CHECK` directives in passing transcoding tests with a sentinel string that won't appear in the actual translator output:

- `test/transcoding/fmax.ll` — broke `CHECK-SPIRV` line
- `test/transcoding/CommonAddrspaceGlobalVar.ll` — broke `CHECK-LLVM` line

### Expected CI behavior

After the workflow runs, the sticky comment from `github-actions[bot]` should:

- Headline: 🔴 **2 new translator lit failures introduced by this PR**
- 🔴 New failures bucket: `transcoding/fmax.ll`, `transcoding/CommonAddrspaceGlobalVar.ll`
- 🟢 Fixed bucket: empty
- ⚠️ Pre-existing bucket: ~21 known amd-staging baseline failures

If the comment shows that, the diff logic is working end-to-end.

Closing without merge once verified.