### PR TITLE
[CI] Rename job to "Linux Build & Test"

### DIFF
--- a/.github/workflows/spirv-ci.yml
+++ b/.github/workflows/spirv-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    name: Build & Test
+    name: Linux Build & Test
     runs-on: azure-linux-scale-rocm
     timeout-minutes: 120
     container:


### PR DESCRIPTION
## Summary

- Renames the SPIRV CI job from `"Build & Test"` → `"Linux Build & Test"`.
- `"Build & Test"` is generic and collides with any other workflow's default. Required-status-check rules match the bare check_run name, so the generic name is risky.
- Adds `"Linux"` to make room for future `"Windows Build & Test"` etc.
- Did NOT add component-list qualifiers (LLVM/Comgr/translator) — the workflow will grow beyond those, so a platform-shaped name is more durable.

## ⚠️ Action required after merge

The ruleset `amd-staging-psdb` (Settings → Rules → Rulesets) currently has required-check context `"SPIRV CI - amd-staging / Build & Test"`. That context format never actually matched (the matcher uses bare check_run.name, not the workflow-prefixed form), so the rule is silently broken today — non-admin merges are blocked, admins bypass.

**On merge, update the ruleset entry to `"Linux Build & Test"`** (bare job name, no workflow prefix, no event suffix). That fixes both the rename and the matching bug at once.

Companion change for the llvm-project copy of this workflow: ROCm/llvm-project#2451.