### PR TITLE
[CI test - DO NOT MERGE] Intentionally break two lit tests (v2)

### DIFF
--- a/test/transcoding/CommonAddrspaceGlobalVar.ll
+++ b/test/transcoding/CommonAddrspaceGlobalVar.ll
@@ -7,7 +7,7 @@
 ; FIXME: FILECHECK_FAIL during llvm-spirv -r in llc compilation flow
 
 ; CHECK-LLVM-NOT: alloca
-; CHECK-LLVM: @CAG = common addrspace(1) global i32 0, align 4
+; CHECK-LLVM: @DELIBERATE_TEST_FAILURE_TO_VERIFY_CI_BASELINE_DIFF = common addrspace(1) global i32 0, align 4
 ; CHECK-LLVM-NOT: alloca
 
 target triple = "spir64-unknown-unknown"

--- a/test/transcoding/fmax.ll
+++ b/test/transcoding/fmax.ll
@@ -7,7 +7,7 @@
 
 ; Check enabling SPV_KHR_fma does not translate fmax to fma.
 
-; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] fmax [[#]] [[#]]
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DELIBERATE_TEST_FAILURE_TO_VERIFY_CI_BASELINE_DIFF [[#]] [[#]]
 
 ; CHECK-LLVM: %{{.*}} = call spir_func float @_Z4fmaxff(float %{{.*}}, float %{{.*}})
 


### PR DESCRIPTION
Modifies `CHECK` directives in two currently-passing transcoding tests with sentinel strings that won't appear in actual translator output:

- `test/transcoding/fmax.ll` — broke `CHECK-SPIRV` line
- `test/transcoding/CommonAddrspaceGlobalVar.ll` — broke `CHECK-LLVM` line