### PR TITLE
[CI] Touch build.ninja after untar to prevent cascade rebuild

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -151,10 +151,12 @@ jobs:
         with:
           name: linux-build-tree
 
-      # -m skips mtime restore so build outputs aren't older than the
-      # freshly-checked-out source — otherwise ninja cascade-rebuilds.
+      # touch build.ninja so it's newer than CMakeCache.txt — without it
+      # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
       - name: Untar build trees
-        run: tar -xmf linux-build-tree.tar
+        run: |
+          tar -xmf linux-build-tree.tar
+          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
 
       - name: Test - SPIRV Translator (check-amd-llvm-spirv) [PR head]
         id: check_spirv_xlator
@@ -317,10 +319,12 @@ jobs:
         with:
           name: linux-build-tree
 
-      # -m skips mtime restore so build outputs aren't older than the
-      # freshly-checked-out source — otherwise ninja cascade-rebuilds.
+      # touch build.ninja so it's newer than CMakeCache.txt — without it
+      # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
       - name: Untar build trees
-        run: tar -xmf linux-build-tree.tar
+        run: |
+          tar -xmf linux-build-tree.tar
+          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
 
       - name: Test - LLVM SPIRV backend (check-llvm-codegen-spirv)
         run: ninja -C build check-llvm-codegen-spirv
@@ -358,10 +362,12 @@ jobs:
         with:
           name: linux-build-tree
 
-      # -m skips mtime restore so build outputs aren't older than the
-      # freshly-checked-out source — otherwise ninja cascade-rebuilds.
+      # touch build.ninja so it's newer than CMakeCache.txt — without it
+      # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
       - name: Untar build trees
-        run: tar -xmf linux-build-tree.tar
+        run: |
+          tar -xmf linux-build-tree.tar
+          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
 
       - name: Test - Comgr (check-comgr)
         # check-comgr depends on test-lit (runs lit suite) and test-unit


### PR DESCRIPTION
## Summary

Test-side ninja invocations (codegen, comgr, translator-lit) cascade-rebuild even with \`tar -xmf\`. Diagnosed in #195:

\`\`\`
ninja explain: output build.ninja older than most recent input CMakeCache.txt
               (1778450813199019645 vs 1778450820955083819)
\`\`\`

\`tar -m\` sets each extracted file's mtime to its individual extraction time. Tar processes files sequentially, so within the build dir some files end up newer than others — \`build.ninja\` (large, extracted earlier) ends up older than \`CMakeCache.txt\` (extracted later). Ninja's regen rule sees an "input newer than build.ninja" → cmake regen → command-hash drift → rebuild everything.

## Fix

After untar, explicitly \`touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja\` so build.ninja is the newest file in the tree. Ninja's regen check passes, no rebuild.

## Why this is the right scope of fix

TheRock avoids this entirely by never shipping build trees — they ship installed artifacts and run \`ctest\` directly against pre-built binaries (no ninja involved). That's the right long-term direction and probably how this workflow looks once it moves into TheRock. For now this 1-line fix unblocks the in-flight PRs (#196 Windows, #2451 llvm-project both hit the same bug) without a full restructure.

After this lands I'll close #195 (the debug PR) and apply the same fix to #196 + #2451.