### PR TITLE
ci: trigger spirv-ci on amd-staging baseline (#206 control test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,6 @@ After at least one release cycle one may remove support for reverse translation 
 at which point support for the "preview extension" is considered removed.
 
 These are guidelines, not requirements, and we will consider exceptions on a case-by-case basis.
+
+<!-- ci: trigger spirv-ci on amd-staging baseline (no functional change) -->
+


### PR DESCRIPTION
Control PR for [#206](https://github.com/ROCm/SPIRV-LLVM-Translator/issues/206).

No functional change — adds a one-line HTML comment to README.md so that `spirv-ci.yml` fires against the amd-staging baseline. The expectation is that this PR will reproduce the same `Comgr :: spirv-tests/*.hip` failures seen on https://github.com/ROCm/SPIRV-LLVM-Translator/pull/205, confirming the regression is in `ROCm/llvm-project amd-staging` clang (bisected to upstream `2825dfa027e6`) and not in the translator.

Do not merge.