### PR TITLE
[CI] Drop translator-lit baseline-diff PR comment (Linux + Windows)

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -138,9 +138,6 @@ jobs:
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
-    permissions:
-      contents: read
-      pull-requests: write   # for the baseline-diff sticky comment
 
     steps:
       - name: Checkout llvm-project (pinned to Build job SHA)
@@ -194,8 +191,9 @@ jobs:
 
       - name: Test - SPIRV Translator [baseline amd-staging]
         # Re-run the lit suite with the translator at amd-staging tip so the
-        # comment script can compute the per-PR delta (new vs fixed vs
-        # pre-existing). Incremental rebuild — only translator objects change.
+        # gating step can flag only PR-introduced failures (filtering out
+        # pre-existing baseline failures). Incremental rebuild — only
+        # translator objects change.
         if: always()
         id: check_spirv_baseline
         continue-on-error: true
@@ -214,72 +212,6 @@ jobs:
           grep -oE '^FAIL: LLVM_SPIRV :: \S+' build/check-amd-llvm-spirv-baseline.log \
             | sort -u > build/spirv-fails-baseline.txt || true
           echo "Baseline failures:"; cat build/spirv-fails-baseline.txt
-
-      - name: Post translator lit summary to PR
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- spirv-ci:translator-lit -->';
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean); }
-              catch { return null; }
-            };
-            const prList = read('build/spirv-fails-pr.txt');
-            const baseList = read('build/spirv-fails-baseline.txt');
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const fmt = (xs) => xs.length ? '```\n' + xs.join('\n') + '\n```' : '_(none)_';
-
-            let body;
-            if (!prList) {
-              body = `${marker}\n⚠️ **SPIRV translator lit suite**: PR run did not produce a result (see [run](${runUrl})).`;
-            } else if (!baseList) {
-              body = prList.length === 0
-                ? `${marker}\n✅ **SPIRV translator lit suite**: all tests passing on PR head. (Baseline comparison unavailable.)`
-                : `${marker}\n⚠️ **SPIRV translator lit suite**: ${prList.length} failing on PR head; baseline comparison unavailable (see [run](${runUrl})).\n\n<details><summary>Failing tests</summary>\n\n${fmt(prList)}\n</details>`;
-            } else {
-              const prSet = new Set(prList);
-              const baseSet = new Set(baseList);
-              const newFails = prList.filter(t => !baseSet.has(t));
-              const fixed = baseList.filter(t => !prSet.has(t));
-              const common = prList.filter(t => baseSet.has(t));
-
-              let headline;
-              if (newFails.length === 0 && fixed.length === 0 && common.length === 0) {
-                headline = `✅ **SPIRV translator lit suite**: clean on both PR head and \`amd-staging\` baseline.`;
-              } else if (newFails.length > 0) {
-                headline = `🔴 **${newFails.length} new translator lit failure${newFails.length === 1 ? '' : 's'}** introduced by this PR (non-blocking; see [run](${runUrl})).`;
-              } else if (fixed.length > 0 && common.length === 0) {
-                headline = `🟢 **SPIRV translator lit suite**: this PR fixes ${fixed.length} test${fixed.length === 1 ? '' : 's'} that fail on \`amd-staging\`. No remaining failures.`;
-              } else if (fixed.length > 0) {
-                headline = `🟢 This PR fixes ${fixed.length} translator lit test${fixed.length === 1 ? '' : 's'} (vs \`amd-staging\` baseline). ${common.length} pre-existing failure${common.length === 1 ? '' : 's'} remain.`;
-              } else {
-                headline = `⚠️ **${common.length} pre-existing translator lit failure${common.length === 1 ? '' : 's'}** on baseline; not caused by this PR (see [run](${runUrl})).`;
-              }
-
-              body = `${marker}\n${headline}\n\n` +
-                `<details${newFails.length > 0 ? ' open' : ''}><summary>🔴 New failures (${newFails.length}) — likely caused by this PR</summary>\n\n${fmt(newFails)}\n</details>\n\n` +
-                `<details><summary>🟢 Fixed by this PR (${fixed.length}) — failing on baseline, passing here</summary>\n\n${fmt(fixed)}\n</details>\n\n` +
-                `<details><summary>⚠️ Pre-existing on \`amd-staging\` (${common.length})</summary>\n\n${fmt(common)}\n</details>`;
-            }
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number, body,
-              });
-            }
 
       # Fail the job on real regressions (PR head FAILs that aren't on
       # amd-staging baseline). Pre-existing baseline failures don't block.

--- a/.github/workflows/spirv-ci-windows.yml
+++ b/.github/workflows/spirv-ci-windows.yml
@@ -148,9 +148,6 @@ jobs:
     needs: build
     runs-on: azure-windows-scale-rocm
     timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write   # for the baseline-diff sticky comment
     defaults:
       run:
         shell: bash
@@ -236,72 +233,6 @@ jobs:
           grep -oE '^FAIL: LLVM_SPIRV :: \S+' build/check-amd-llvm-spirv-baseline.log \
             | sort -u > build/spirv-fails-baseline.txt || true
           echo "Baseline failures:"; cat build/spirv-fails-baseline.txt
-
-      - name: Post translator lit summary to PR
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- spirv-ci:translator-lit-windows -->';
-            const read = (p) => {
-              try { return fs.readFileSync(p, 'utf8').split('\n').filter(Boolean); }
-              catch { return null; }
-            };
-            const prList = read('build/spirv-fails-pr.txt');
-            const baseList = read('build/spirv-fails-baseline.txt');
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const fmt = (xs) => xs.length ? '```\n' + xs.join('\n') + '\n```' : '_(none)_';
-
-            let body;
-            if (!prList) {
-              body = `${marker}\n⚠️ **SPIRV translator lit suite (Windows)**: PR run did not produce a result (see [run](${runUrl})).`;
-            } else if (!baseList) {
-              body = prList.length === 0
-                ? `${marker}\n✅ **SPIRV translator lit suite (Windows)**: all tests passing on PR head. (Baseline comparison unavailable.)`
-                : `${marker}\n⚠️ **SPIRV translator lit suite (Windows)**: ${prList.length} failing on PR head; baseline comparison unavailable (see [run](${runUrl})).\n\n<details><summary>Failing tests</summary>\n\n${fmt(prList)}\n</details>`;
-            } else {
-              const prSet = new Set(prList);
-              const baseSet = new Set(baseList);
-              const newFails = prList.filter(t => !baseSet.has(t));
-              const fixed = baseList.filter(t => !prSet.has(t));
-              const common = prList.filter(t => baseSet.has(t));
-
-              let headline;
-              if (newFails.length === 0 && fixed.length === 0 && common.length === 0) {
-                headline = `✅ **SPIRV translator lit suite (Windows)**: clean on both PR head and \`amd-staging\` baseline.`;
-              } else if (newFails.length > 0) {
-                headline = `🔴 **${newFails.length} new translator lit failure${newFails.length === 1 ? '' : 's'} (Windows)** introduced by this PR (non-blocking; see [run](${runUrl})).`;
-              } else if (fixed.length > 0 && common.length === 0) {
-                headline = `🟢 **SPIRV translator lit suite (Windows)**: this PR fixes ${fixed.length} test${fixed.length === 1 ? '' : 's'} that fail on \`amd-staging\`. No remaining failures.`;
-              } else if (fixed.length > 0) {
-                headline = `🟢 This PR fixes ${fixed.length} translator lit test${fixed.length === 1 ? '' : 's'} on Windows (vs \`amd-staging\` baseline). ${common.length} pre-existing failure${common.length === 1 ? '' : 's'} remain.`;
-              } else {
-                headline = `⚠️ **${common.length} pre-existing translator lit failure${common.length === 1 ? '' : 's'} (Windows)** on baseline; not caused by this PR (see [run](${runUrl})).`;
-              }
-
-              body = `${marker}\n${headline}\n\n` +
-                `<details${newFails.length > 0 ? ' open' : ''}><summary>🔴 New failures (${newFails.length}) — likely caused by this PR</summary>\n\n${fmt(newFails)}\n</details>\n\n` +
-                `<details><summary>🟢 Fixed by this PR (${fixed.length}) — failing on baseline, passing here</summary>\n\n${fmt(fixed)}\n</details>\n\n` +
-                `<details><summary>⚠️ Pre-existing on \`amd-staging\` (${common.length})</summary>\n\n${fmt(common)}\n</details>`;
-            }
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                comment_id: existing.id, body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number, body,
-              });
-            }
 
       - name: Gate - new translator lit failures
         if: always()


### PR DESCRIPTION
## Summary

The Gate step in both `spirv-ci-linux.yml` and `spirv-ci-windows.yml` already fails the job (and emits `::error` annotations) on PR-introduced translator lit failures, surfacing exactly the same signal as the sticky PR comments. Now that the diff check has stabilized, the comments are redundant noise.

## Changes

- Remove the "Post translator lit summary to PR" `github-script` step from both Linux and Windows translator-lit jobs.
- Drop the job-level `pull-requests: write` permission (no longer needed; only `contents: read` from the default workflow scope remains).
- Update one stale comment in `spirv-ci-linux.yml` that referenced the removed comment script.

The baseline run, capture steps, and gating logic are unchanged — the new/fixed/pre-existing partitioning still drives the Gate step's pass/fail decision; it just no longer renders to a PR comment.

The matching change on the `ROCm/llvm-project` copy of these workflows has already been applied separately.