### PR TITLE
[CI] Drop potentialAction from upstream-merge Teams cards

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -133,15 +133,8 @@ jobs:
                 "name": "Branch",
                 "value": "${{ steps.merge.outputs.branch }}"
               }],
+              "text": "[View PR](${{ steps.create-pr.outputs.pr_url }})",
               "markdown": true
-            }],
-            "potentialAction": [{
-              "@type": "OpenUri",
-              "name": "View PR",
-              "targets": [{
-                "os": "default",
-                "uri": "${{ steps.create-pr.outputs.pr_url }}"
-              }]
             }]
           }' "${{ secrets.TEAMS_WEBHOOK_URL }}"
 
@@ -193,15 +186,7 @@ jobs:
                 "name": "Total Conflicts",
                 "value": "'"$CONFLICT_COUNT"' file(s)"
               }],
-              "text": "Automatic merge of upstream main into amd-staging failed due to conflicts. Manual intervention required.",
+              "text": "Automatic merge of upstream main into amd-staging failed due to conflicts. Manual intervention required.<br><br>[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · [View repository](${{ github.server_url }}/${{ github.repository }})",
               "markdown": true
-            }],
-            "potentialAction": [{
-              "@type": "OpenUri",
-              "name": "View Repository",
-              "targets": [{
-                "os": "default",
-                "uri": "${{ github.server_url }}/${{ github.repository }}"
-              }]
             }]
           }' "${{ secrets.TEAMS_WEBHOOK_URL }}"


### PR DESCRIPTION
## Summary

The Teams incoming-webhook endpoint returns **HTTP 403** for `MessageCard` payloads containing `potentialAction` (OpenUri buttons). The `Notify Teams - PR Created` and `Notify Teams - Merge Conflict` steps have been silently dropped — `curl` did not exit non-zero on the 403, so workflow runs reported success while no card arrived.

The `Notify Teams - No Changes` card has no `potentialAction` and still posts fine, which is why we believed the workflow was healthy.

## Repro

Replaying this morning's conflict payload (run [26566609972](https://github.com/ROCm/SPIRV-LLVM-Translator/actions/runs/26566609972)) against the live webhook:

- Original payload (with `potentialAction`): `HTTP 403`, empty body
- Same payload minus `potentialAction`: `HTTP 200`, body `1`

## Fix

Replace the OpenUri buttons with inline markdown links in the card's `text` field. The conflict card now links both to the workflow run and the repository, since the workflow run page is where someone investigating the conflict actually needs to go.

## Background

Microsoft has been progressively restricting actionable content in Office 365 connectors. Long term, these webhooks are slated for retirement in favor of Power Automate / Workflows; this change keeps the existing notifications working in the meantime.