### PR TITLE
[CI] Auto-enable merge-commit auto-merge on upstream-merge PRs

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -117,6 +117,15 @@ jobs:
           )")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
+      - name: Enable auto-merge (merge commit)
+        if: steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Lock merge method to "Create a merge commit" to preserve upstream ancestry.
+          gh pr merge "${{ steps.create-pr.outputs.pr_url }}" --auto --merge \
+            || echo "::warning::Could not enable auto-merge; reviewers must pick 'Create a merge commit' manually."
+
       - name: Notify Teams - PR Created
         if: steps.merge.outputs.conflict == 'false'
         run: |


### PR DESCRIPTION
Locks the merge method to "Create a merge commit" when the workflow opens the PR, so it can't be accidentally squash-merged. Falls back to a workflow warning if auto-merge isn't available.