### PR TITLE
[CI] Add hip-tests kernel suite in SPIRV mode

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -702,6 +702,8 @@ jobs:
             -DHIP_PLATFORM=amd \
             -DROCM_PATH=$STAGING \
             -DCMAKE_PREFIX_PATH="$STAGING;$STAGING/lib/cmake" \
+            -DCMAKE_C_COMPILER=$LLVM_PATH/bin/clang \
+            -DCMAKE_CXX_COMPILER=$LLVM_PATH/bin/clang++ \
             -DCMAKE_HIP_COMPILER=$LLVM_PATH/bin/clang++ \
             -DCMAKE_HIP_COMPILER_ROCM_ROOT=$STAGING \
             -DCMAKE_HIP_ARCHITECTURES=amdgcnspirv \

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -472,9 +472,13 @@ jobs:
             rocm-examples/HIP-Basic/hello_world/main.hip
 
       - name: Run hello-world
+        # AMD_LOG_LEVEL=3 + HIP_LAUNCH_BLOCKING=1: diagnostic. Surfaces whether
+        # the kernel actually launches and whether hipDeviceSynchronize returns
+        # cleanly. Remove once the rocm-examples flow is stable.
         run: |
           STAGING=$PWD/staging
-          LD_LIBRARY_PATH=$STAGING/lib ./hello_world | tee run.log
+          AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 \
+            LD_LIBRARY_PATH=$STAGING/lib ./hello_world 2>&1 | tee run.log
 
       - name: Check expected output
         # hello-world prints fixed host + device greetings. Exact line

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -480,12 +480,15 @@ jobs:
             rocm-examples/HIP-Basic/hello_world/main.hip
 
       - name: Run hello-world
-        # AMD_LOG_LEVEL=3 + HIP_LAUNCH_BLOCKING=1: diagnostic. Surfaces whether
-        # the kernel actually launches and whether hipDeviceSynchronize returns
-        # cleanly. Remove once the rocm-examples flow is stable.
+        # Diagnostic mode while we stabilize the SPIR-V JIT path:
+        # AMD_LOG_LEVEL=3 + HIP_LAUNCH_BLOCKING=1: HIP runtime trace
+        # AMD_COMGR_REDIRECT_LOGS=stderr: surface comgr's "spirv to reloc"
+        #   error detail when JIT fails.
         run: |
           STAGING=$PWD/staging
-          AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 \
+          echo "=== staging/bin (translator) ==="
+          ls -la $STAGING/bin/ || true
+          AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 AMD_COMGR_REDIRECT_LOGS=stderr \
             LD_LIBRARY_PATH=$STAGING/lib ./hello_world 2>&1 | tee run.log
 
       - name: Check expected output

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -481,15 +481,21 @@ jobs:
 
       - name: Run hello-world
         # Diagnostic mode while we stabilize the SPIR-V JIT path:
-        # AMD_LOG_LEVEL=3 + HIP_LAUNCH_BLOCKING=1: HIP runtime trace
-        # AMD_COMGR_REDIRECT_LOGS=stderr: surface comgr's "spirv to reloc"
-        #   error detail when JIT fails.
+        # - AMD_LOG_LEVEL=3, HIP_LAUNCH_BLOCKING=1: HIP runtime trace.
+        # - AMD_COMGR_REDIRECT_LOGS=stderr + AMD_COMGR_SAVE_TEMPS=/tmp/comgr:
+        #   surface Comgr error detail + dump intermediate files.
+        # - ROCM_PATH=$STAGING: hint Comgr to find device-libs in staging
+        #   instead of falling back to /opt/rocm.
         run: |
           STAGING=$PWD/staging
-          echo "=== staging/bin (translator) ==="
-          ls -la $STAGING/bin/ || true
-          AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 AMD_COMGR_REDIRECT_LOGS=stderr \
+          mkdir -p /tmp/comgr
+          ROCM_PATH=$STAGING \
+            AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 \
+            AMD_COMGR_REDIRECT_LOGS=stderr \
+            AMD_COMGR_SAVE_TEMPS=/tmp/comgr \
             LD_LIBRARY_PATH=$STAGING/lib ./hello_world 2>&1 | tee run.log
+          echo "=== /tmp/comgr (intermediate files) ==="
+          ls -la /tmp/comgr/ 2>&1 || true
 
       - name: Check expected output
         # hello-world prints fixed host + device greetings. Exact line

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -190,6 +190,15 @@ jobs:
       - name: Build CLR
         run: ninja -C build-clr install
 
+      - name: Stage translator binary for runtime SPIRV JIT
+        # HIP runtime calls Comgr at kernel-launch to translate the embedded
+        # SPIR-V to AMDGPU code. Comgr looks for the translator at
+        # <libamd_comgr.so dir>/../bin/amd-llvm-spirv. Copy it (and the
+        # llvm-spirv symlink) from the LLVM build dir into staging/bin/.
+        run: |
+          mkdir -p staging/bin
+          cp -a build/bin/amd-llvm-spirv build/bin/llvm-spirv staging/bin/
+
       # ---- Strip + upload artifact -----------------------------------------
       # Strip binaries to keep the artifact under GHA's 10GB cap and shorten
       # upload/download time. Tests don't need debug symbols. `--strip-unneeded`

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -147,6 +147,8 @@ jobs:
         # LLVM_DIR/Clang_DIR are explicit because rocr-runtime's
         # trap_handler/CMakeLists.txt does find_package(Clang) and will
         # otherwise grab a stale system-installed clang config.
+        # CMAKE_INSTALL_LIBDIR=lib because the manylinux container defaults
+        # to lib64 and clang's --rocm-path looks at <prefix>/lib.
         run: |
           cmake -G Ninja -S rocm-systems/projects/rocr-runtime -B build-rocr \
             -DCMAKE_BUILD_TYPE=Release \
@@ -154,6 +156,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=$PWD/staging \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
             -DClang_DIR=$PWD/build/lib/cmake/clang
 
@@ -175,6 +178,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=$PWD/staging \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_PREFIX_PATH="$PWD/staging;$PWD/build;$PWD/rocm-cmake/share/rocm" \
             -DHIP_PLATFORM=amd \
             -DHIP_COMMON_DIR=$PWD/rocm-systems/projects/hip \
@@ -453,22 +457,12 @@ jobs:
       - name: Untar build trees
         run: tar -xmf linux-build-tree.tar
 
-      - name: Debug - inspect staging tree
-        run: |
-          STAGING=$PWD/staging
-          echo "=== staging/lib (amdhip64 + hsa-runtime) ==="
-          ls -la $STAGING/lib/ | grep -E "amdhip64|hsa-runtime|amd_comgr" || true
-          echo "=== staging/ top-level ==="
-          ls $STAGING/
-          echo "=== are there any other libdirs (lib64, etc)? ==="
-          find $STAGING -maxdepth 2 -name "lib*" -type d 2>/dev/null
-
       - name: Compile hello-world via amdgcnspirv
-        # -v surfaces what clang-linker-wrapper is invoked with so we can see
-        # whether -L gets forwarded. LIBRARY_PATH covers its own lib search.
+        # -Wl,-rpath bakes the runtime path so the binary finds the libs
+        # without LD_LIBRARY_PATH at exec.
         run: |
           STAGING=$PWD/staging
-          LIBRARY_PATH=$STAGING/lib $PWD/build/bin/clang++ -v -std=c++17 \
+          $PWD/build/bin/clang++ -std=c++17 \
             -x hip --offload-arch=amdgcnspirv \
             --rocm-path=$STAGING \
             -I rocm-examples/Common \

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -575,7 +575,6 @@ jobs:
 
           while IFS= read -r exe; do
             [ -z "$exe" ] && continue
-            [ -x "./$exe" ] || continue
             if timeout 60 "./$exe" > "/tmp/${exe}.out" 2>&1; then
               RUN_OK+=("$exe")
               echo "RUN OK:   $exe"

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -120,9 +120,34 @@ jobs:
         # <prefix>/lib/cmake/amd_comgr, <prefix>/amdgcn/bitcode/ — the
         # installed-tree layout that clang's `--rocm-path` and CLR's
         # find_package(amd_comgr) both expect. Build-dir layouts won't do.
+        #
+        # Backfill the libamd_comgr.so.<MAJOR> SONAME symlink if Comgr's
+        # install rules didn't create it. Without it, the dynamic loader
+        # falls through LD_LIBRARY_PATH and resolves libamd_comgr.so.3
+        # from /opt/rocm-* on the test runner — which is an older Comgr
+        # whose API doesn't match what our libamdhip64 was built against.
         run: |
           cmake --install build-comgr --prefix $PWD/staging
           cmake --install build-device-libs --prefix $PWD/staging
+          echo "=== staging/lib after install (comgr files) ==="
+          ls -la staging/lib/libamd_comgr* 2>&1 || true
+          cd staging/lib
+          # Find the highest-versioned libamd_comgr.so.M.m.p and ensure SONAME
+          # symlink libamd_comgr.so.<MAJOR> points to it.
+          full=$(ls libamd_comgr.so.*.*.* 2>/dev/null | head -1)
+          if [ -n "$full" ]; then
+            major=$(echo "$full" | sed 's/libamd_comgr\.so\.\([0-9]*\)\..*/\1/')
+            if [ ! -e "libamd_comgr.so.$major" ]; then
+              ln -s "$full" "libamd_comgr.so.$major"
+              echo "Created SONAME symlink: libamd_comgr.so.$major -> $full"
+            fi
+            if [ ! -e "libamd_comgr.so" ]; then
+              ln -s "libamd_comgr.so.$major" "libamd_comgr.so"
+              echo "Created dev symlink: libamd_comgr.so -> libamd_comgr.so.$major"
+            fi
+          fi
+          echo "=== staging/lib after backfill (comgr files) ==="
+          ls -la libamd_comgr* 2>&1 || true
 
       - name: Checkout rocm-systems (pinned)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -98,20 +98,106 @@ jobs:
       - name: Build Comgr
         run: ninja -C build-comgr amd_comgr
 
+      # ---- In-pipeline HIP runtime build ----------------------------------
+      # Builds ROCR-Runtime (libhsa-runtime64.so) and CLR (libamdhip64.so)
+      # against the just-built clang, plus installs comgr + device-libs into
+      # the same staging tree. Result: a self-contained ROCm install layout
+      # under `staging/` that PR clang can target via `--rocm-path` to
+      # compile and run HIP for `--offload-arch=amdgcnspirv`.
+      #
+      # Why in-pipeline (vs pulling a prebuilt nightly tarball): TheRock's
+      # public `therock-nightly-tarball` bucket only publishes consumer
+      # (dgpu) families on a daily cadence; gfx94X / gfx950 (dcgpu) tarballs
+      # stopped Oct 2025, and TheRock's own multi-arch CI for those families
+      # builds the runtime in-pipeline for the same reason.
+      - name: Install build deps for runtime build
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            numactl-devel elfutils-libelf-devel libdrm-devel || true
+
+      - name: Install comgr + device-libs into staging
+        # CMake `--install` lays them out under <prefix>/include/amd_comgr,
+        # <prefix>/lib/cmake/amd_comgr, <prefix>/amdgcn/bitcode/ — the
+        # installed-tree layout that clang's `--rocm-path` and CLR's
+        # find_package(amd_comgr) both expect. Build-dir layouts won't do.
+        run: |
+          cmake --install build-comgr --prefix $PWD/staging
+          cmake --install build-device-libs --prefix $PWD/staging
+
+      - name: Checkout rocm-systems (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/rocm-systems
+          ref: 8bb3b73c117e5630106540447268ccad771906a4 # develop, 2026-05-15
+          path: rocm-systems
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout rocm-cmake (pinned)
+        # Provides ROCM cmake modules (ROCMConfig) that CLR's build needs.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/rocm-cmake
+          ref: 4d391d7bda62a0f476dbadb383e99f4508c7415d # develop, 2026-05-12
+          path: rocm-cmake
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure ROCR-Runtime
+        # LLVM_DIR/Clang_DIR are explicit because rocr-runtime's
+        # trap_handler/CMakeLists.txt does find_package(Clang) and will
+        # otherwise grab a stale system-installed clang config.
+        run: |
+          cmake -G Ninja -S rocm-systems/projects/rocr-runtime -B build-rocr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=$PWD/build/bin/clang \
+            -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=$PWD/staging \
+            -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
+            -DClang_DIR=$PWD/build/lib/cmake/clang
+
+      - name: Build ROCR-Runtime
+        run: ninja -C build-rocr install
+
+      - name: Configure CLR (HIP runtime)
+        # ROCM_KPACK_ENABLED, HIP_ENABLE_ROCPROFILER_REGISTER, HIPCC_BIN_DIR=
+        # are explicit-disable knobs for optional deps we don't need; without
+        # them the configure errors out with REQUIRED-not-found.
+        run: |
+          cmake -G Ninja -S rocm-systems/projects/clr -B build-clr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=$PWD/build/bin/clang \
+            -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=$PWD/staging \
+            -DCMAKE_PREFIX_PATH="$PWD/staging;$PWD/build;$PWD/rocm-cmake/share/rocm" \
+            -DHIP_PLATFORM=amd \
+            -DHIP_COMMON_DIR=$PWD/rocm-systems/projects/hip \
+            -DCLR_BUILD_HIP=ON \
+            -DROCM_KPACK_ENABLED=OFF \
+            -DHIP_ENABLE_ROCPROFILER_REGISTER=OFF \
+            -DHIPCC_BIN_DIR=
+
+      - name: Build CLR
+        run: ninja -C build-clr install
+
       # ---- Strip + upload artifact -----------------------------------------
       # Strip binaries to keep the artifact under GHA's 10GB cap and shorten
       # upload/download time. Tests don't need debug symbols. `--strip-unneeded`
       # preserves dynamic symbols needed at link/load time.
       - name: Strip binaries
         run: |
-          find build build-comgr build-device-libs \
+          find build build-comgr build-device-libs build-rocr build-clr staging \
             -type f \( -executable -o -name '*.so*' -o -name '*.a' \) \
             -exec strip --strip-unneeded {} + 2>/dev/null || true
 
       # Tar before upload: actions/upload-artifact@v4 strips +x bits and
       # excludes hidden files (loses FetchContent .git dirs).
       - name: Tar build trees
-        run: tar -cf linux-build-tree.tar build build-comgr build-device-libs
+        run: |
+          tar -cf linux-build-tree.tar \
+            build build-comgr build-device-libs build-rocr build-clr staging
 
       - name: Upload build tree artifact
         uses: actions/upload-artifact@v4
@@ -331,3 +417,62 @@ jobs:
         env:
           AMD_COMGR_REDIRECT_LOGS: stderr
         run: ctest --test-dir build-comgr --output-on-failure --rerun-failed
+
+  # =====================================================================
+  # Test - rocm-examples (compile + run hello-world via amdgcnspirv)
+  # =====================================================================
+  # Drives PR clang through the SPIRV translator on a real HIP example
+  # and JIT-runs the SPIR-V on a gfx942 GPU. Catches translator/codegen
+  # bugs that pass lit but fail at runtime kernel-load. Informational
+  # initially; promote to required once stable.
+  test_rocm_examples:
+    name: Test rocm-examples
+    needs: build
+    runs-on: linux-gfx942-1gpu-ossci-rocm
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout rocm-examples (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/rocm-examples
+          ref: b4ee9992e851a078c99d93de59d6142a51f5e3a1 # develop, 2025-02-21
+          path: rocm-examples
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download build tree artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build-tree
+
+      - name: Untar build trees
+        run: tar -xmf linux-build-tree.tar
+
+      - name: Compile hello-world via amdgcnspirv
+        # `--rocm-path=$STAGING` lets PR clang find headers + device-libs
+        # + runtime libs from the in-pipeline-built ROCm tree. `-lhsa-runtime64`
+        # is needed explicitly: the executable link doesn't pull it in
+        # transitively from libamdhip64.so.
+        run: |
+          STAGING=$PWD/staging
+          $PWD/build/bin/clang++ -std=c++17 \
+            -x hip --offload-arch=amdgcnspirv \
+            --rocm-path=$STAGING \
+            -I rocm-examples/Common \
+            -L $STAGING/lib -lamdhip64 -lhsa-runtime64 \
+            -o hello_world \
+            rocm-examples/HIP-Basic/hello_world/main.hip
+
+      - name: Run hello-world
+        run: |
+          STAGING=$PWD/staging
+          LD_LIBRARY_PATH=$STAGING/lib ./hello_world | tee run.log
+
+      - name: Check expected output
+        # hello-world prints fixed host + device greetings. Exact line
+        # ordering between blocks is non-deterministic but the set is fixed.
+        run: |
+          grep -q "^Hello world from host!" run.log
+          grep -q "^Hello world from device kernel block 0 thread 0!" run.log
+          grep -q "^Hello world from device kernel block 1 thread 1!" run.log

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -158,6 +158,10 @@ jobs:
             -DClang_DIR=$PWD/build/lib/cmake/clang
 
       - name: Build ROCR-Runtime
+        # ROCM_PATH points clang at our staging tree when ROCR's image lib
+        # compiles OpenCL blit bitcode (no /opt/rocm in the CI container).
+        env:
+          ROCM_PATH: ${{ github.workspace }}/staging
         run: ninja -C build-rocr install
 
       - name: Configure CLR (HIP runtime)

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -600,9 +600,13 @@ jobs:
       - name: Run rocm-examples
         # Runs everything built: HIP-Basic binaries from examples-build/bin
         # plus the Applications + Tutorials binaries from the bash-loop
-        # compile. Gates on exit code 0 (60s timeout each). hip_cooperative_groups
-        # is skipped: known SPIR-V codegen bug — "Cannot select intrinsic
-        # %llvm.amdgcn.s.wait.asynccnt" — pending an AMDGPU backend fix.
+        # compile. Gates on exit code 0 (60s timeout each).
+        #
+        # hip_cooperative_groups is currently a known failure
+        # ("Cannot select intrinsic %llvm.amdgcn.s.wait.asynccnt") and is
+        # intentionally left in the gating set — the whole point of this
+        # job is to keep surfacing this kind of break until the AMDGPU
+        # backend gets a lowering pattern. Remove this note once fixed.
         run: |
           set +e
           STAGING=$PWD/staging
@@ -610,16 +614,9 @@ jobs:
 
           RUN_OK=()
           RUN_FAILED=()
-          SKIPPED=()
 
           run_one() {
             local exe="$1" label="$2"
-            case "$exe" in *hip_cooperative_groups)
-              SKIPPED+=("$label")
-              echo "SKIP:     $label (known SPIRV limitation)"
-              return 0
-              ;;
-            esac
             if timeout 60 "$exe" > "/tmp/$(basename $exe).out" 2>&1; then
               RUN_OK+=("$label")
               echo "RUN OK:   $label"
@@ -645,9 +642,8 @@ jobs:
 
           echo ""
           echo "=== Run summary ==="
-          echo "Passed:  ${#RUN_OK[@]}"
-          echo "Skipped: ${#SKIPPED[@]}"
-          echo "Failed:  ${#RUN_FAILED[@]}"
+          echo "Passed: ${#RUN_OK[@]}"
+          echo "Failed: ${#RUN_FAILED[@]}"
           for f in "${RUN_FAILED[@]}"; do echo "  - $f"; done
 
           [ ${#RUN_FAILED[@]} -eq 0 ]

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -193,11 +193,10 @@ jobs:
       - name: Stage translator binary for runtime SPIRV JIT
         # HIP runtime calls Comgr at kernel-launch to translate the embedded
         # SPIR-V to AMDGPU code. Comgr looks for the translator at
-        # <libamd_comgr.so dir>/../bin/amd-llvm-spirv. Copy it (and the
-        # llvm-spirv symlink) from the LLVM build dir into staging/bin/.
+        # <libamd_comgr.so dir>/../bin/amd-llvm-spirv.
         run: |
           mkdir -p staging/bin
-          cp -a build/bin/amd-llvm-spirv build/bin/llvm-spirv staging/bin/
+          cp -a build/bin/amd-llvm-spirv staging/bin/
 
       # ---- Strip + upload artifact -----------------------------------------
       # Strip binaries to keep the artifact under GHA's 10GB cap and shorten

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -453,13 +453,22 @@ jobs:
       - name: Untar build trees
         run: tar -xmf linux-build-tree.tar
 
-      - name: Compile hello-world via amdgcnspirv
-        # LIBRARY_PATH covers clang-linker-wrapper's own lib search (it doesn't
-        # inherit -L from the driver). -L covers the host linker.
-        # -Wl,-rpath bakes the runtime path into the binary.
+      - name: Debug - inspect staging tree
         run: |
           STAGING=$PWD/staging
-          LIBRARY_PATH=$STAGING/lib $PWD/build/bin/clang++ -std=c++17 \
+          echo "=== staging/lib (amdhip64 + hsa-runtime) ==="
+          ls -la $STAGING/lib/ | grep -E "amdhip64|hsa-runtime|amd_comgr" || true
+          echo "=== staging/ top-level ==="
+          ls $STAGING/
+          echo "=== are there any other libdirs (lib64, etc)? ==="
+          find $STAGING -maxdepth 2 -name "lib*" -type d 2>/dev/null
+
+      - name: Compile hello-world via amdgcnspirv
+        # -v surfaces what clang-linker-wrapper is invoked with so we can see
+        # whether -L gets forwarded. LIBRARY_PATH covers its own lib search.
+        run: |
+          STAGING=$PWD/staging
+          LIBRARY_PATH=$STAGING/lib $PWD/build/bin/clang++ -v -std=c++17 \
             -x hip --offload-arch=amdgcnspirv \
             --rocm-path=$STAGING \
             -I rocm-examples/Common \

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -127,8 +127,6 @@ jobs:
         run: |
           cmake --install build-comgr --prefix $PWD/staging
           cmake --install build-device-libs --prefix $PWD/staging
-          echo "=== staging/lib after install (comgr files) ==="
-          ls -la staging/lib/libamd_comgr* 2>&1 || true
 
       - name: Checkout rocm-systems (pinned)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -214,7 +212,7 @@ jobs:
             -type f \( -executable -o -name '*.so*' -o -name '*.a' \) \
             -exec strip --strip-unneeded {} + 2>/dev/null || true
 
-      # Tar before upload: actions/upload-artifact@v4 strips +x bits and
+      # Tar before upload: actions/upload-artifact@v7 strips +x bits and
       # excludes hidden files (loses FetchContent .git dirs).
       - name: Tar build trees
         run: |
@@ -222,7 +220,7 @@ jobs:
             build build-comgr build-device-libs build-rocr build-clr staging
 
       - name: Upload build tree artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-build-tree
           path: linux-build-tree.tar
@@ -265,7 +263,7 @@ jobs:
           persist-credentials: false
 
       - name: Download build tree artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-build-tree
 
@@ -368,7 +366,7 @@ jobs:
           persist-credentials: false
 
       - name: Download build tree artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-build-tree
 
@@ -411,7 +409,7 @@ jobs:
           persist-credentials: false
 
       - name: Download build tree artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-build-tree
 
@@ -464,7 +462,7 @@ jobs:
           persist-credentials: false
 
       - name: Download build tree artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-build-tree
 
@@ -563,38 +561,6 @@ jobs:
           printf '%s\n' "${BUILD_OK[@]}" > built_examples.txt
 
           [ ${#BUILD_FAILED[@]} -eq 0 ]
-
-      - name: Dump fatbin contents
-        # Diagnostic: list what targets are bundled in the binary's .hip_fatbin
-        # section. Helps verify SPIR-V actually got embedded with the right
-        # target string vs LLVM IR or some other format.
-        run: |
-          echo "=== .hip_fatbin section ==="
-          $PWD/build/bin/llvm-objdump -h hello_world | grep -E "fatbin|hip_" || true
-          echo "=== Extract and list bundle ==="
-          $PWD/build/bin/llvm-objcopy --dump-section=.hip_fatbin=hello_world.fatbin hello_world || true
-          $PWD/build/bin/clang-offload-bundler --type=o --input=hello_world.fatbin --list 2>&1 | head -20 || true
-          echo "=== strings(hello_world) | grep amdgcn ==="
-          strings hello_world | grep -iE "amdgcn|spirv" | head -10 || true
-
-      - name: Probe runner state + clean caches
-        # Confirm what HIP/Comgr libs are actually getting loaded — there's
-        # a /opt/rocm-6.4.1 on the runner that could be overriding our
-        # staged tree via libamdhip64's rpath/runpath.
-        run: |
-          STAGING=$PWD/staging
-          echo "=== /opt/rocm ==="
-          ls -d /opt/rocm* 2>&1 || true
-          echo "=== ldd ./hello_world (with our LD_LIBRARY_PATH) ==="
-          LD_LIBRARY_PATH=$STAGING/lib ldd ./hello_world 2>&1 | grep -iE "amdhip|amd_comgr|hsa-runtime|hsakmt" || true
-          echo "=== rpath/runpath of staged libamdhip64.so ==="
-          readelf -d $STAGING/lib/libamdhip64.so | grep -iE "runpath|rpath|needed" | head -10 || true
-          echo "=== rpath/runpath of staged libamd_comgr.so ==="
-          readelf -d $STAGING/lib/libamd_comgr.so | grep -iE "runpath|rpath" | head -5 || true
-          echo "=== Comgr cache ==="
-          ls -la ~/.cache/comgr 2>&1 | head -3 || echo "no ~/.cache/comgr"
-          ls -la ~/.amd/comgr 2>&1 | head -3 || echo "no ~/.amd/comgr"
-          rm -rf ~/.cache/comgr ~/.amd/comgr || true
 
       - name: Run rocm-examples
         # Runs each example that built. Gates on exit code 0 (any non-zero

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -454,17 +454,17 @@ jobs:
         run: tar -xmf linux-build-tree.tar
 
       - name: Compile hello-world via amdgcnspirv
-        # `--rocm-path=$STAGING` lets PR clang find headers + device-libs
-        # + runtime libs from the in-pipeline-built ROCm tree. `-lhsa-runtime64`
-        # is needed explicitly: the executable link doesn't pull it in
-        # transitively from libamdhip64.so.
+        # LIBRARY_PATH covers clang-linker-wrapper's own lib search (it doesn't
+        # inherit -L from the driver). -L covers the host linker.
+        # -Wl,-rpath bakes the runtime path into the binary.
         run: |
           STAGING=$PWD/staging
-          $PWD/build/bin/clang++ -std=c++17 \
+          LIBRARY_PATH=$STAGING/lib $PWD/build/bin/clang++ -std=c++17 \
             -x hip --offload-arch=amdgcnspirv \
             --rocm-path=$STAGING \
             -I rocm-examples/Common \
-            -L $STAGING/lib -lamdhip64 -lhsa-runtime64 \
+            -L $STAGING/lib -Wl,-rpath,$STAGING/lib \
+            -lamdhip64 -lhsa-runtime64 \
             -o hello_world \
             rocm-examples/HIP-Basic/hello_world/main.hip
 

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -489,6 +489,19 @@ jobs:
             -o hello_world \
             rocm-examples/HIP-Basic/hello_world/main.hip
 
+      - name: Dump fatbin contents
+        # Diagnostic: list what targets are bundled in the binary's .hip_fatbin
+        # section. Helps verify SPIR-V actually got embedded with the right
+        # target string vs LLVM IR or some other format.
+        run: |
+          echo "=== .hip_fatbin section ==="
+          $PWD/build/bin/llvm-objdump -h hello_world | grep -E "fatbin|hip_" || true
+          echo "=== Extract and list bundle ==="
+          $PWD/build/bin/llvm-objcopy --dump-section=.hip_fatbin=hello_world.fatbin hello_world || true
+          $PWD/build/bin/clang-offload-bundler --type=o --input=hello_world.fatbin --list 2>&1 | head -20 || true
+          echo "=== strings(hello_world) | grep amdgcn ==="
+          strings hello_world | grep -iE "amdgcn|spirv" | head -10 || true
+
       - name: Run hello-world
         # Diagnostic mode while we stabilize the SPIR-V JIT path:
         # - AMD_LOG_LEVEL=3, HIP_LAUNCH_BLOCKING=1: HIP runtime trace.

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -504,17 +504,16 @@ jobs:
 
       - name: Run hello-world
         # Diagnostic mode while we stabilize the SPIR-V JIT path:
-        # - AMD_LOG_LEVEL=3, HIP_LAUNCH_BLOCKING=1: HIP runtime trace.
-        # - AMD_COMGR_REDIRECT_LOGS=stderr + AMD_COMGR_SAVE_TEMPS=/tmp/comgr:
-        #   surface Comgr error detail + dump intermediate files.
-        # - ROCM_PATH=$STAGING: hint Comgr to find device-libs in staging
-        #   instead of falling back to /opt/rocm.
+        # AMD_COMGR_EMIT_VERBOSE_LOGS=1 forces Comgr to log internals
+        # without HIP having to enable per-action logging — needed to see
+        # what AMD_COMGR_ACTION_COMPILE_SPIRV_TO_RELOCATABLE is failing on.
         run: |
           STAGING=$PWD/staging
           mkdir -p /tmp/comgr
           ROCM_PATH=$STAGING \
             AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 \
             AMD_COMGR_REDIRECT_LOGS=stderr \
+            AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
             AMD_COMGR_SAVE_TEMPS=/tmp/comgr \
             LD_LIBRARY_PATH=$STAGING/lib ./hello_world 2>&1 | tee run.log
           echo "=== /tmp/comgr (intermediate files) ==="

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -503,19 +503,22 @@ jobs:
           strings hello_world | grep -iE "amdgcn|spirv" | head -10 || true
 
       - name: Probe runner state + clean caches
-        # The gfx942 ossci-rocm runner is persistent (no container), so state
-        # carries across runs. Wipe Comgr's JIT cache (cached failures would
-        # otherwise stick around) and report what else is on the box that
-        # could interfere with our staged ROCm tree.
+        # Confirm what HIP/Comgr libs are actually getting loaded — there's
+        # a /opt/rocm-6.4.1 on the runner that could be overriding our
+        # staged tree via libamdhip64's rpath/runpath.
         run: |
+          STAGING=$PWD/staging
           echo "=== /opt/rocm ==="
-          ls -la /opt/rocm/ 2>&1 | head -5 || echo "no /opt/rocm"
-          echo "=== rocm-* in /opt ==="
           ls -d /opt/rocm* 2>&1 || true
+          echo "=== ldd ./hello_world (with our LD_LIBRARY_PATH) ==="
+          LD_LIBRARY_PATH=$STAGING/lib ldd ./hello_world 2>&1 | grep -iE "amdhip|amd_comgr|hsa-runtime|hsakmt" || true
+          echo "=== rpath/runpath of staged libamdhip64.so ==="
+          readelf -d $STAGING/lib/libamdhip64.so | grep -iE "runpath|rpath|needed" | head -10 || true
+          echo "=== rpath/runpath of staged libamd_comgr.so ==="
+          readelf -d $STAGING/lib/libamd_comgr.so | grep -iE "runpath|rpath" | head -5 || true
           echo "=== Comgr cache ==="
-          ls -la ~/.cache/comgr 2>&1 | head -10 || echo "no ~/.cache/comgr"
-          ls -la ~/.amd/comgr 2>&1 | head -10 || echo "no ~/.amd/comgr"
-          echo "=== wiping caches ==="
+          ls -la ~/.cache/comgr 2>&1 | head -3 || echo "no ~/.cache/comgr"
+          ls -la ~/.amd/comgr 2>&1 | head -3 || echo "no ~/.amd/comgr"
           rm -rf ~/.cache/comgr ~/.amd/comgr || true
 
       - name: Run hello-world

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -56,26 +56,46 @@ jobs:
 
       # ---- Build LLVM + Clang + LLD + in-tree SPIRV translator --------------
       - name: Configure LLVM
+        # CMAKE_INSTALL_LIBDIR=lib because the manylinux container's
+        # GNUInstallDirs defaults to lib64, which trips up downstream
+        # CMake projects (rocm-examples uses CMAKE_HIP_COMPILER_ROCM_ROOT
+        # which expects <root>/lib).
+        # compiler-rt is included with builtins only (all other features
+        # off): hip-lang-config.cmake hard-requires libclang_rt.builtins.a
+        # for any downstream project that does `enable_language(HIP)`.
         run: |
           cmake -G Ninja -S llvm-project/llvm -B build \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
             -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_INSTALL_GTEST=ON \
-            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -DCOMPILER_RT_BUILD_BUILTINS=ON \
+            -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+            -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+            -DCOMPILER_RT_BUILD_PROFILE=OFF \
+            -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+            -DCOMPILER_RT_BUILD_XRAY=OFF \
+            -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
+            -DCOMPILER_RT_BUILD_ORC=OFF \
+            -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
 
       - name: Build LLVM + Clang + amd-llvm-spirv + test deps
         # *-test-depends pull in all tools needed for lit (FileCheck, not,
         # llc, llvm-*, clang, opt, etc.) and stay current with upstream.
-        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv
+        # `builtins` builds libclang_rt.builtins.a (see Configure comment).
+        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv builtins
 
       # ---- Build device-libs (standalone, against built LLVM) --------------
       - name: Configure device-libs
         run: |
           cmake -G Ninja -S llvm-project/amd/device-libs -B build-device-libs \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_PREFIX_PATH=$PWD/build \
             -DLLVM_DIR=$PWD/build/lib/cmake/llvm
 
@@ -450,6 +470,13 @@ jobs:
     needs: build
     runs-on: linux-gfx942-1gpu-ossci-rocm
     timeout-minutes: 45
+    # Run inside the same manylinux container as the Build job (glibc
+    # consistency with the built libs) with GPU passthrough — keeps the
+    # job isolated from whatever ROCm install or Comgr cache might exist
+    # on the persistent host runner.
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+      options: --device=/dev/kfd --device=/dev/dri --group-add video
 
     steps:
       - name: Checkout rocm-examples (pinned)
@@ -469,42 +496,60 @@ jobs:
       - name: Untar build trees
         run: tar -xmf linux-build-tree.tar
 
-      - name: Compile rocm-examples
-        # Iterates the same example sets ROCm/RocmCIForSPIRV's
-        # spirv_external_llvm.sh builds for SPIR-V mode:
-        #   - SIMPLE_EXAMPLES:   HIP-Basic single-source examples (16)
-        #   - EXTERNAL_EXAMPLES: HIP-Basic + External/ include (2)
-        #   - runtime_compilation: HIP-Basic + -lhiprtc (1)
-        #   - APPLICATIONS:      Applications/ + External/ include (6)
-        #   - REDUCTION:         Tutorials/reduction v1..v9, c++20 (9)
-        # Excluded: opengl/vulkan interop, hello_world_cuda, hipify,
-        # assembly_to_executable, llvm_ir_to_executable, sobel_filter
-        # (need libs we don't have or use native-AMDGPU codepaths
-        # incompatible with SPIR-V). multi_gpu_data_transfer requires
-        # >1 GPU; this runner is 1gpu-ossci-rocm. Library-conditional
-        # examples (rocPRIM, hipCUB, monte_carlo_pi via hipRAND) need
-        # rocm-libraries math-libs which we don't build here.
-        # Flags match the working compile invocation from RocmCIForSPIRV.
+      - name: Install runtime deps in container
+        run: dnf install -y numactl-libs
+
+      # ---- HIP-Basic: build via rocm-examples' own CMake -------------------
+      - name: Build HIP-Basic via rocm-examples CMake
+        # Uses rocm-examples' upstream CMakeLists, which already auto-skips
+        # SPIR-V-incompatible examples (assembly_to_executable,
+        # llvm_ir_to_executable, opengl/vulkan_interop, hello_world_cuda,
+        # hipify, sobel_filter) via find_package / GPU_RUNTIME gates.
+        # The HIP_PLATFORM=amd + ROCM_PATH=$STAGING combo bypasses the
+        # hipconfig probe that hip-config.cmake does (hipconfig isn't
+        # staged). CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY avoids
+        # try_compile linking against an unfound HIP runtime during
+        # find_package.
+        run: |
+          STAGING=$PWD/staging
+          LLVM_PATH=$PWD/build
+          cmake -S rocm-examples/HIP-Basic -B examples-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_COMPILER=$LLVM_PATH/bin/clang++ \
+            -DCMAKE_HIP_COMPILER=$LLVM_PATH/bin/clang++ \
+            -DCMAKE_HIP_COMPILER_ROCM_ROOT=$STAGING \
+            -DCMAKE_HIP_ARCHITECTURES=amdgcnspirv \
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Perl=TRUE \
+            -DHIP_PLATFORM=amd \
+            -DROCM_PATH=$STAGING \
+            -DCMAKE_HIP_FLAGS="--rocm-path=$STAGING --rtlib=libgcc -unwindlib=libgcc" \
+            -DCMAKE_HIP_LINK_FLAGS="--rtlib=libgcc -unwindlib=libgcc -L$STAGING/lib -Wl,-rpath,$STAGING/lib -Wl,--unresolved-symbols=ignore-in-shared-libs" \
+            -DCMAKE_CXX_FLAGS="--rtlib=libgcc -unwindlib=libgcc" \
+            -DCMAKE_EXE_LINKER_FLAGS="--rtlib=libgcc -unwindlib=libgcc -L$STAGING/lib -Wl,-rpath,$STAGING/lib -Wl,--unresolved-symbols=ignore-in-shared-libs" \
+            -DCMAKE_SHARED_LINKER_FLAGS="--rtlib=libgcc -unwindlib=libgcc"
+          cmake --build examples-build -j
+
+      # ---- Applications + Tutorials: bash loop (their CMake pulls in --------
+      # hipcub/rocrand/rocfft find_packages we don't have staged) -----------
+      - name: Compile rocm-examples Applications + Tutorials
+        # Builds the example sets ROCm/RocmCIForSPIRV's
+        # spirv_external_llvm.sh covers that aren't in HIP-Basic:
+        #   - APPLICATIONS: Applications/ + External/ include (6)
+        #   - REDUCTION:    Tutorials/reduction v1..v9, c++20 (9)
+        # HIP-Basic itself is built via CMake above.
         run: |
           set +e
           STAGING=$PWD/staging
           CLANG=$PWD/build/bin/clang++
 
-          SIMPLE_EXAMPLES=(
-            bit_extract cooperative_groups device_globals device_query
-            dynamic_shared events gpu_arch hello_world
-            inline_assembly moving_average occupancy saxpy
-            shared_memory streams texture_management warp_shuffle
-          )
-          # HIP-Basic examples that need -I External
-          EXTERNAL_EXAMPLES=(bandwidth matrix_multiplication)
           APPLICATIONS=(
             bitonic_sort convolution fdtd floyd_warshall histogram prefix_sum
           )
           REDUCTION_VERSIONS=(v1 v2 v3 v4 v5 v6 v7 v8 v9)
 
           BASE_FLAGS=(
-            -x hip --offload-arch=amdgcnspirv --offload-new-driver
+            -x hip --offload-arch=amdgcnspirv
             -D__HIP_PLATFORM_AMD__
             --rocm-path=$STAGING
             --rocm-device-lib-path=$STAGING/amdgcn/bitcode
@@ -534,15 +579,6 @@ jobs:
             fi
           }
 
-          for ex in "${SIMPLE_EXAMPLES[@]}"; do
-            build_one "$ex" "rocm-examples/HIP-Basic/$ex/main.hip" ""
-          done
-          for ex in "${EXTERNAL_EXAMPLES[@]}"; do
-            build_one "$ex" "rocm-examples/HIP-Basic/$ex/main.hip" "-I rocm-examples/External"
-          done
-          # runtime_compilation needs libhiprtc at link time.
-          build_one "runtime_compilation" \
-            "rocm-examples/HIP-Basic/runtime_compilation/main.hip" "-lhiprtc"
           for ex in "${APPLICATIONS[@]}"; do
             build_one "$ex" "rocm-examples/Applications/$ex/main.hip" "-I rocm-examples/External"
           done
@@ -552,19 +588,21 @@ jobs:
           done
 
           echo ""
-          echo "=== Compile summary ==="
+          echo "=== Compile summary (Applications + Tutorials) ==="
           echo "Built:  ${#BUILD_OK[@]}"
           echo "Failed: ${#BUILD_FAILED[@]}"
           for f in "${BUILD_FAILED[@]}"; do echo "  - $f"; done
 
-          # Persist the built list for the Run step.
           printf '%s\n' "${BUILD_OK[@]}" > built_examples.txt
 
           [ ${#BUILD_FAILED[@]} -eq 0 ]
 
       - name: Run rocm-examples
-        # Runs each example that built. Gates on exit code 0 (any non-zero
-        # = crash / hipError / assert). 60s timeout per example.
+        # Runs everything built: HIP-Basic binaries from examples-build/bin
+        # plus the Applications + Tutorials binaries from the bash-loop
+        # compile. Gates on exit code 0 (60s timeout each). hip_cooperative_groups
+        # is skipped: known SPIR-V codegen bug — "Cannot select intrinsic
+        # %llvm.amdgcn.s.wait.asynccnt" — pending an AMDGPU backend fix.
         run: |
           set +e
           STAGING=$PWD/staging
@@ -572,23 +610,44 @@ jobs:
 
           RUN_OK=()
           RUN_FAILED=()
+          SKIPPED=()
 
+          run_one() {
+            local exe="$1" label="$2"
+            case "$exe" in *hip_cooperative_groups)
+              SKIPPED+=("$label")
+              echo "SKIP:     $label (known SPIRV limitation)"
+              return 0
+              ;;
+            esac
+            if timeout 60 "$exe" > "/tmp/$(basename $exe).out" 2>&1; then
+              RUN_OK+=("$label")
+              echo "RUN OK:   $label"
+            else
+              local rc=$?
+              RUN_FAILED+=("$label")
+              echo "RUN FAIL: $label (exit $rc)"
+              head -10 "/tmp/$(basename $exe).out"
+            fi
+          }
+
+          # HIP-Basic (CMake build → examples-build/bin/)
+          for exe in examples-build/bin/*; do
+            [ -x "$exe" ] || continue
+            run_one "$exe" "$(basename $exe)"
+          done
+
+          # Applications + Tutorials (bash-loop build → cwd)
           while IFS= read -r exe; do
             [ -z "$exe" ] && continue
-            if timeout 60 "./$exe" > "/tmp/${exe}.out" 2>&1; then
-              RUN_OK+=("$exe")
-              echo "RUN OK:   $exe"
-            else
-              RUN_FAILED+=("$exe")
-              echo "RUN FAIL: $exe (exit $?)"
-              head -10 "/tmp/${exe}.out"
-            fi
+            run_one "./$exe" "$exe"
           done < built_examples.txt
 
           echo ""
           echo "=== Run summary ==="
-          echo "Passed: ${#RUN_OK[@]}"
-          echo "Failed: ${#RUN_FAILED[@]}"
+          echo "Passed:  ${#RUN_OK[@]}"
+          echo "Skipped: ${#SKIPPED[@]}"
+          echo "Failed:  ${#RUN_FAILED[@]}"
           for f in "${RUN_FAILED[@]}"; do echo "  - $f"; done
 
           [ ${#RUN_FAILED[@]} -eq 0 ]

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -502,6 +502,22 @@ jobs:
           echo "=== strings(hello_world) | grep amdgcn ==="
           strings hello_world | grep -iE "amdgcn|spirv" | head -10 || true
 
+      - name: Probe runner state + clean caches
+        # The gfx942 ossci-rocm runner is persistent (no container), so state
+        # carries across runs. Wipe Comgr's JIT cache (cached failures would
+        # otherwise stick around) and report what else is on the box that
+        # could interfere with our staged ROCm tree.
+        run: |
+          echo "=== /opt/rocm ==="
+          ls -la /opt/rocm/ 2>&1 | head -5 || echo "no /opt/rocm"
+          echo "=== rocm-* in /opt ==="
+          ls -d /opt/rocm* 2>&1 || true
+          echo "=== Comgr cache ==="
+          ls -la ~/.cache/comgr 2>&1 | head -10 || echo "no ~/.cache/comgr"
+          ls -la ~/.amd/comgr 2>&1 | head -10 || echo "no ~/.amd/comgr"
+          echo "=== wiping caches ==="
+          rm -rf ~/.cache/comgr ~/.amd/comgr || true
+
       - name: Run hello-world
         # Diagnostic mode while we stabilize the SPIR-V JIT path:
         # AMD_COMGR_EMIT_VERBOSE_LOGS=1 forces Comgr to log internals

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -87,9 +87,13 @@ jobs:
         # LLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR points Comgr at
         # the in-tree translator headers so COMGR_SPIRV_TRANSLATOR_AVAILABLE
         # turns ON (otherwise translator-dependent lit tests are UNSUPPORTED).
+        # CMAKE_INSTALL_LIBDIR=lib so the install lands in staging/lib (not
+        # lib64) and the runtime resolver finds libamd_comgr.so.3 there
+        # instead of falling through to /opt/rocm on the test runner.
         run: |
           cmake -G Ninja -S llvm-project/amd/comgr -B build-comgr \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
             -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
             -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm-project/llvm/projects/SPIRV-LLVM-Translator \
@@ -120,34 +124,11 @@ jobs:
         # <prefix>/lib/cmake/amd_comgr, <prefix>/amdgcn/bitcode/ — the
         # installed-tree layout that clang's `--rocm-path` and CLR's
         # find_package(amd_comgr) both expect. Build-dir layouts won't do.
-        #
-        # Backfill the libamd_comgr.so.<MAJOR> SONAME symlink if Comgr's
-        # install rules didn't create it. Without it, the dynamic loader
-        # falls through LD_LIBRARY_PATH and resolves libamd_comgr.so.3
-        # from /opt/rocm-* on the test runner — which is an older Comgr
-        # whose API doesn't match what our libamdhip64 was built against.
         run: |
           cmake --install build-comgr --prefix $PWD/staging
           cmake --install build-device-libs --prefix $PWD/staging
           echo "=== staging/lib after install (comgr files) ==="
           ls -la staging/lib/libamd_comgr* 2>&1 || true
-          cd staging/lib
-          # Find the highest-versioned libamd_comgr.so.M.m.p and ensure SONAME
-          # symlink libamd_comgr.so.<MAJOR> points to it.
-          full=$(ls libamd_comgr.so.*.*.* 2>/dev/null | head -1)
-          if [ -n "$full" ]; then
-            major=$(echo "$full" | sed 's/libamd_comgr\.so\.\([0-9]*\)\..*/\1/')
-            if [ ! -e "libamd_comgr.so.$major" ]; then
-              ln -s "$full" "libamd_comgr.so.$major"
-              echo "Created SONAME symlink: libamd_comgr.so.$major -> $full"
-            fi
-            if [ ! -e "libamd_comgr.so" ]; then
-              ln -s "libamd_comgr.so.$major" "libamd_comgr.so"
-              echo "Created dev symlink: libamd_comgr.so -> libamd_comgr.so.$major"
-            fi
-          fi
-          echo "=== staging/lib after backfill (comgr files) ==="
-          ls -la libamd_comgr* 2>&1 || true
 
       - name: Checkout rocm-systems (pinned)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -474,13 +474,18 @@ jobs:
       - name: Compile rocm-examples
         # Iterates the same example sets ROCm/RocmCIForSPIRV's
         # spirv_external_llvm.sh builds for SPIR-V mode:
-        #   - SIMPLE_EXAMPLES: HIP-Basic single-source examples
-        #   - APPLICATIONS:    HIP-Basic + External/ include
-        #   - REDUCTION:       Tutorials/reduction v1..v9 (c++20)
-        # Excluded examples (opengl/vulkan interop, hello_world_cuda,
-        # hipify, assembly_to_executable, llvm_ir_to_executable,
-        # sobel_filter) either need libraries we don't have or use
-        # native-AMDGPU code paths incompatible with SPIR-V.
+        #   - SIMPLE_EXAMPLES:   HIP-Basic single-source examples (16)
+        #   - EXTERNAL_EXAMPLES: HIP-Basic + External/ include (2)
+        #   - runtime_compilation: HIP-Basic + -lhiprtc (1)
+        #   - APPLICATIONS:      Applications/ + External/ include (6)
+        #   - REDUCTION:         Tutorials/reduction v1..v9, c++20 (9)
+        # Excluded: opengl/vulkan interop, hello_world_cuda, hipify,
+        # assembly_to_executable, llvm_ir_to_executable, sobel_filter
+        # (need libs we don't have or use native-AMDGPU codepaths
+        # incompatible with SPIR-V). multi_gpu_data_transfer requires
+        # >1 GPU; this runner is 1gpu-ossci-rocm. Library-conditional
+        # examples (rocPRIM, hipCUB, monte_carlo_pi via hipRAND) need
+        # rocm-libraries math-libs which we don't build here.
         # Flags match the working compile invocation from RocmCIForSPIRV.
         run: |
           set +e
@@ -493,6 +498,8 @@ jobs:
             inline_assembly moving_average occupancy saxpy
             shared_memory streams texture_management warp_shuffle
           )
+          # HIP-Basic examples that need -I External
+          EXTERNAL_EXAMPLES=(bandwidth matrix_multiplication)
           APPLICATIONS=(
             bitonic_sort convolution fdtd floyd_warshall histogram prefix_sum
           )
@@ -532,6 +539,12 @@ jobs:
           for ex in "${SIMPLE_EXAMPLES[@]}"; do
             build_one "$ex" "rocm-examples/HIP-Basic/$ex/main.hip" ""
           done
+          for ex in "${EXTERNAL_EXAMPLES[@]}"; do
+            build_one "$ex" "rocm-examples/HIP-Basic/$ex/main.hip" "-I rocm-examples/External"
+          done
+          # runtime_compilation needs libhiprtc at link time.
+          build_one "runtime_compilation" \
+            "rocm-examples/HIP-Basic/runtime_compilation/main.hip" "-lhiprtc"
           for ex in "${APPLICATIONS[@]}"; do
             build_one "$ex" "rocm-examples/Applications/$ex/main.hip" "-I rocm-examples/External"
           done

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -466,15 +466,25 @@ jobs:
         run: tar -xmf linux-build-tree.tar
 
       - name: Compile hello-world via amdgcnspirv
-        # -Wl,-rpath bakes the runtime path so the binary finds the libs
-        # without LD_LIBRARY_PATH at exec.
+        # Flags chosen to match ROCm/RocmCIForSPIRV spirv_external_llvm.sh:
+        # --offload-new-driver routes through the HIP offload codepath that
+        # produces a fatbin HIP runtime can JIT for amdgcnspirv. Without it,
+        # the runtime fails with "Failed to compile spirv to reloc" because
+        # the bundle isn't in the format it expects.
+        # --rocm-device-lib-path explicit because --rocm-path's auto-detect
+        # doesn't always pick up the staged amdgcn/bitcode/ dir.
+        # --unresolved-symbols=ignore-in-shared-libs because libamd_comgr.so
+        # embeds its own LLVM symbols.
         run: |
           STAGING=$PWD/staging
           $PWD/build/bin/clang++ -std=c++17 \
-            -x hip --offload-arch=amdgcnspirv \
+            -x hip --offload-arch=amdgcnspirv --offload-new-driver \
+            -D__HIP_PLATFORM_AMD__ \
             --rocm-path=$STAGING \
+            --rocm-device-lib-path=$STAGING/amdgcn/bitcode \
             -I rocm-examples/Common \
             -L $STAGING/lib -Wl,-rpath,$STAGING/lib \
+            -Wl,--unresolved-symbols=ignore-in-shared-libs \
             -lamdhip64 -lhsa-runtime64 \
             -o hello_world \
             rocm-examples/HIP-Basic/hello_world/main.hip

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -451,14 +451,14 @@ jobs:
     name: Test rocm-examples
     needs: build
     runs-on: linux-gfx942-1gpu-ossci-rocm
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     steps:
       - name: Checkout rocm-examples (pinned)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ROCm/rocm-examples
-          ref: b4ee9992e851a078c99d93de59d6142a51f5e3a1 # develop, 2025-02-21
+          ref: e260595e2ec06f8a8714bd67bb1bc93d6c27e589 # amd-staging, 2026-05-28
           path: rocm-examples
           fetch-depth: 1
           persist-credentials: false
@@ -471,29 +471,85 @@ jobs:
       - name: Untar build trees
         run: tar -xmf linux-build-tree.tar
 
-      - name: Compile hello-world via amdgcnspirv
-        # Flags chosen to match ROCm/RocmCIForSPIRV spirv_external_llvm.sh:
-        # --offload-new-driver routes through the HIP offload codepath that
-        # produces a fatbin HIP runtime can JIT for amdgcnspirv. Without it,
-        # the runtime fails with "Failed to compile spirv to reloc" because
-        # the bundle isn't in the format it expects.
-        # --rocm-device-lib-path explicit because --rocm-path's auto-detect
-        # doesn't always pick up the staged amdgcn/bitcode/ dir.
-        # --unresolved-symbols=ignore-in-shared-libs because libamd_comgr.so
-        # embeds its own LLVM symbols.
+      - name: Compile rocm-examples
+        # Iterates the same example sets ROCm/RocmCIForSPIRV's
+        # spirv_external_llvm.sh builds for SPIR-V mode:
+        #   - SIMPLE_EXAMPLES: HIP-Basic single-source examples
+        #   - APPLICATIONS:    HIP-Basic + External/ include
+        #   - REDUCTION:       Tutorials/reduction v1..v9 (c++20)
+        # Excluded examples (opengl/vulkan interop, hello_world_cuda,
+        # hipify, assembly_to_executable, llvm_ir_to_executable,
+        # sobel_filter) either need libraries we don't have or use
+        # native-AMDGPU code paths incompatible with SPIR-V.
+        # Flags match the working compile invocation from RocmCIForSPIRV.
         run: |
+          set +e
           STAGING=$PWD/staging
-          $PWD/build/bin/clang++ -std=c++17 \
-            -x hip --offload-arch=amdgcnspirv --offload-new-driver \
-            -D__HIP_PLATFORM_AMD__ \
-            --rocm-path=$STAGING \
-            --rocm-device-lib-path=$STAGING/amdgcn/bitcode \
-            -I rocm-examples/Common \
-            -L $STAGING/lib -Wl,-rpath,$STAGING/lib \
-            -Wl,--unresolved-symbols=ignore-in-shared-libs \
-            -lamdhip64 -lhsa-runtime64 \
-            -o hello_world \
-            rocm-examples/HIP-Basic/hello_world/main.hip
+          CLANG=$PWD/build/bin/clang++
+
+          SIMPLE_EXAMPLES=(
+            bit_extract cooperative_groups device_globals device_query
+            dynamic_shared events gpu_arch hello_world
+            inline_assembly moving_average occupancy saxpy
+            shared_memory streams texture_management warp_shuffle
+          )
+          APPLICATIONS=(
+            bitonic_sort convolution fdtd floyd_warshall histogram prefix_sum
+          )
+          REDUCTION_VERSIONS=(v1 v2 v3 v4 v5 v6 v7 v8 v9)
+
+          BASE_FLAGS=(
+            -x hip --offload-arch=amdgcnspirv --offload-new-driver
+            -D__HIP_PLATFORM_AMD__
+            --rocm-path=$STAGING
+            --rocm-device-lib-path=$STAGING/amdgcn/bitcode
+            -L $STAGING/lib -Wl,-rpath,$STAGING/lib
+            -Wl,--unresolved-symbols=ignore-in-shared-libs
+            -lamdhip64 -lhsa-runtime64
+          )
+
+          BUILD_FAILED=()
+          BUILD_OK=()
+
+          build_one() {
+            local name="$1" src="$2" extra_inc="$3" cxxstd="${4:-c++17}"
+            if [ ! -f "$src" ]; then
+              echo "SKIP $name (no source at $src)"
+              return 0
+            fi
+            if $CLANG -std=$cxxstd "${BASE_FLAGS[@]}" \
+                  -I rocm-examples/Common $extra_inc \
+                  -o "$name" "$src" 2>/tmp/build_err.txt; then
+              BUILD_OK+=("$name")
+              echo "BUILD OK:   $name"
+            else
+              BUILD_FAILED+=("$name")
+              echo "BUILD FAIL: $name"
+              head -8 /tmp/build_err.txt
+            fi
+          }
+
+          for ex in "${SIMPLE_EXAMPLES[@]}"; do
+            build_one "$ex" "rocm-examples/HIP-Basic/$ex/main.hip" ""
+          done
+          for ex in "${APPLICATIONS[@]}"; do
+            build_one "$ex" "rocm-examples/Applications/$ex/main.hip" "-I rocm-examples/External"
+          done
+          for v in "${REDUCTION_VERSIONS[@]}"; do
+            build_one "reduction_$v" "rocm-examples/Tutorials/reduction/example/$v.hip" \
+              "-I rocm-examples/Tutorials/reduction/include" "c++20"
+          done
+
+          echo ""
+          echo "=== Compile summary ==="
+          echo "Built:  ${#BUILD_OK[@]}"
+          echo "Failed: ${#BUILD_FAILED[@]}"
+          for f in "${BUILD_FAILED[@]}"; do echo "  - $f"; done
+
+          # Persist the built list for the Run step.
+          printf '%s\n' "${BUILD_OK[@]}" > built_examples.txt
+
+          [ ${#BUILD_FAILED[@]} -eq 0 ]
 
       - name: Dump fatbin contents
         # Diagnostic: list what targets are bundled in the binary's .hip_fatbin
@@ -527,27 +583,34 @@ jobs:
           ls -la ~/.amd/comgr 2>&1 | head -3 || echo "no ~/.amd/comgr"
           rm -rf ~/.cache/comgr ~/.amd/comgr || true
 
-      - name: Run hello-world
-        # Diagnostic mode while we stabilize the SPIR-V JIT path:
-        # AMD_COMGR_EMIT_VERBOSE_LOGS=1 forces Comgr to log internals
-        # without HIP having to enable per-action logging — needed to see
-        # what AMD_COMGR_ACTION_COMPILE_SPIRV_TO_RELOCATABLE is failing on.
+      - name: Run rocm-examples
+        # Runs each example that built. Gates on exit code 0 (any non-zero
+        # = crash / hipError / assert). 60s timeout per example.
         run: |
+          set +e
           STAGING=$PWD/staging
-          mkdir -p /tmp/comgr
-          ROCM_PATH=$STAGING \
-            AMD_LOG_LEVEL=3 HIP_LAUNCH_BLOCKING=1 \
-            AMD_COMGR_REDIRECT_LOGS=stderr \
-            AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
-            AMD_COMGR_SAVE_TEMPS=/tmp/comgr \
-            LD_LIBRARY_PATH=$STAGING/lib ./hello_world 2>&1 | tee run.log
-          echo "=== /tmp/comgr (intermediate files) ==="
-          ls -la /tmp/comgr/ 2>&1 || true
+          export LD_LIBRARY_PATH=$STAGING/lib
 
-      - name: Check expected output
-        # hello-world prints fixed host + device greetings. Exact line
-        # ordering between blocks is non-deterministic but the set is fixed.
-        run: |
-          grep -q "^Hello world from host!" run.log
-          grep -q "^Hello world from device kernel block 0 thread 0!" run.log
-          grep -q "^Hello world from device kernel block 1 thread 1!" run.log
+          RUN_OK=()
+          RUN_FAILED=()
+
+          while IFS= read -r exe; do
+            [ -z "$exe" ] && continue
+            [ -x "./$exe" ] || continue
+            if timeout 60 "./$exe" > "/tmp/${exe}.out" 2>&1; then
+              RUN_OK+=("$exe")
+              echo "RUN OK:   $exe"
+            else
+              RUN_FAILED+=("$exe")
+              echo "RUN FAIL: $exe (exit $?)"
+              head -10 "/tmp/${exe}.out"
+            fi
+          done < built_examples.txt
+
+          echo ""
+          echo "=== Run summary ==="
+          echo "Passed: ${#RUN_OK[@]}"
+          echo "Failed: ${#RUN_FAILED[@]}"
+          for f in "${RUN_FAILED[@]}"; do echo "  - $f"; done
+
+          [ ${#RUN_FAILED[@]} -eq 0 ]

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -647,3 +647,80 @@ jobs:
           for f in "${RUN_FAILED[@]}"; do echo "  - $f"; done
 
           [ ${#RUN_FAILED[@]} -eq 0 ]
+
+  # =====================================================================
+  # Test - hip-tests (catch2 kernel suite via amdgcnspirv)
+  # =====================================================================
+  # Builds the hip-tests `kernel` catch2 unit suite with -DENABLE_SPIRV=ON
+  # (which sets --offload-arch=amdgcnspirv and gates out SPIR-V-incompatible
+  # cases), then runs it via ctest on a gfx942 GPU. Prototype scope: just
+  # the `kernel` unit dir to start; expand to more unit dirs once the
+  # baseline is characterized. Informational initially.
+  test_hip_tests:
+    name: Test hip-tests
+    needs: build
+    runs-on: linux-gfx942-1gpu-ossci-rocm
+    timeout-minutes: 60
+    # Same manylinux container + GPU passthrough as test_rocm_examples:
+    # isolates from any system ROCm / Comgr cache on the persistent host.
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+      options: --device=/dev/kfd --device=/dev/dri --group-add video
+
+    steps:
+      - name: Checkout hip-tests (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/hip-tests
+          ref: d01e1f96059edc25600eb13434d7e2b71c09af01 # develop, 2026-06-03
+          path: hip-tests
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download build tree artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-build-tree
+
+      - name: Untar build trees
+        run: tar -xmf linux-build-tree.tar
+
+      - name: Install runtime deps in container
+        run: dnf install -y numactl-libs
+
+      - name: Configure hip-tests (ENABLE_SPIRV)
+        # ENABLE_SPIRV=ON makes hip-tests' own CMake set
+        # --offload-arch=amdgcnspirv and exclude SPIR-V-incompatible cases.
+        # Point CMAKE_HIP_COMPILER + hip's find_package at the staged tree;
+        # HIP_PLATFORM=amd + ROCM_PATH bypass the hipconfig probe.
+        run: |
+          STAGING=$PWD/staging
+          LLVM_PATH=$PWD/build
+          cmake -S hip-tests/catch -B hip-tests-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_SPIRV=ON \
+            -DHIP_PLATFORM=amd \
+            -DROCM_PATH=$STAGING \
+            -DCMAKE_PREFIX_PATH="$STAGING;$STAGING/lib/cmake" \
+            -DCMAKE_HIP_COMPILER=$LLVM_PATH/bin/clang++ \
+            -DCMAKE_HIP_COMPILER_ROCM_ROOT=$STAGING \
+            -DCMAKE_HIP_ARCHITECTURES=amdgcnspirv \
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Perl=TRUE \
+            -DCMAKE_HIP_FLAGS="--rocm-path=$STAGING --rtlib=libgcc -unwindlib=libgcc" \
+            -DCMAKE_HIP_LINK_FLAGS="--rtlib=libgcc -unwindlib=libgcc -L$STAGING/lib -Wl,-rpath,$STAGING/lib -Wl,--unresolved-symbols=ignore-in-shared-libs" \
+            -DCMAKE_CXX_FLAGS="--rtlib=libgcc -unwindlib=libgcc" \
+            -DCMAKE_EXE_LINKER_FLAGS="--rtlib=libgcc -unwindlib=libgcc -L$STAGING/lib -Wl,-rpath,$STAGING/lib -Wl,--unresolved-symbols=ignore-in-shared-libs" \
+            -DCMAKE_SHARED_LINKER_FLAGS="--rtlib=libgcc -unwindlib=libgcc"
+
+      - name: Build hip-tests kernel suite
+        run: cmake --build hip-tests-build --target KernelTest -j
+
+      - name: Run hip-tests kernel suite (ctest)
+        # catch_discover_tests registered each catch2 case with ctest.
+        # -R Kernel restricts to the kernel suite's cases. Gates on any
+        # ctest failure.
+        run: |
+          STAGING=$PWD/staging
+          export LD_LIBRARY_PATH=$STAGING/lib
+          ctest --test-dir hip-tests-build -R Kernel --output-on-failure


### PR DESCRIPTION
## Summary

Adds a `test_hip_tests` job that builds the hip-tests `kernel` catch2 unit suite with `-DENABLE_SPIRV=ON` and runs it via ctest on a gfx942 GPU runner. Exercises the SPIRV translator through HIP's own test suite — complements the rocm-examples coverage with structured catch2 test cases.

**Prototype scope:** just the `kernel` unit dir to start. Expand to more unit dirs (memory, stream, device, ...) once the SPIR-V baseline is characterized.

## Why hip-tests is a clean fit

hip-tests has **first-class SPIR-V support**: `-DENABLE_SPIRV=ON` makes its own CMake:
- set `--offload-arch=amdgcnspirv`
- gate out cases that can't run in SPIR-V mode (per-test `if(NOT ENABLE_SPIRV)` blocks)

catch2's `catch_discover_tests` registers each case with ctest, so the flow is just: configure → `cmake --build --target KernelTest` → `ctest -R Kernel`. No hand-rolled bash loop.

## Reuse from the rocm-examples PR

This shares the in-pipeline runtime build (rocr-runtime + CLR + Comgr → `staging/`), the manylinux container with GPU passthrough, and the lib/lib64 + libgcc runtime-lib flags from #208.

## Stacking

Based on `users/lambj/spirv-ci-rocm-examples` (#208) since it inherits the Build-job changes. Will rebase onto `amd-staging` once #208 lands. **Review #208 first.**

## Pin

- `ROCm/hip-tests`: `d01e1f96` (develop, 2026-06-03)

## Status

Informational initially. Once the kernel baseline is green (or known failures characterized), expand unit-dir coverage and consider gating.