### PR TITLE
Avoid duplicate spirv-preserve-auxdata registration with LLVM SPIR-V backend (#3774)

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -219,11 +219,6 @@ static cl::opt<bool>
     SPIRVMemToReg("spirv-mem2reg", cl::init(false),
                   cl::desc("LLVM/SPIR-V translation enable mem2reg"));
 
-static cl::opt<bool>
-    SPIRVPreserveAuxData("spirv-preserve-auxdata", cl::init(false),
-                         cl::desc("Preserve all auxiliary data, such as "
-                                  "function attributes and metadata"));
-
 static cl::opt<bool> SpecConstInfo(
     "spec-const-info",
     cl::desc("Display id of constants available for specializaion and their "
@@ -842,12 +837,22 @@ int main(int Ac, char **Av) {
     OptToDisable->setArgStr("spirv-ext-coming-from-spirv-backend");
     OptToDisable->setHiddenFlag(cl::Hidden);
   }
+  if (RegisteredOptions.count("spirv-preserve-auxdata") == 1) {
+    llvm::cl::Option *OptToDisable =
+        RegisteredOptions["spirv-preserve-auxdata"];
+    OptToDisable->setArgStr("spirv-preserve-auxdata-coming-from-spirv-backend");
+    OptToDisable->setHiddenFlag(cl::Hidden);
+  }
 #endif
   cl::list<std::string> SPVExt(
       "spirv-ext", cl::CommaSeparated,
       cl::desc("Specify list of allowed/disallowed extensions"),
       cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
       cl::ValueRequired);
+  cl::opt<bool> SPIRVPreserveAuxData(
+      "spirv-preserve-auxdata", cl::init(false),
+      cl::desc("Preserve all auxiliary data, such as function attributes and "
+               "metadata"));
 
   cl::ParseCommandLineOptions(Ac, Av, "LLVM/SPIR-V translator");
 


### PR DESCRIPTION
Cherry-pick of upstream KhronosGroup/SPIRV-LLVM-Translator#3774 (26682004be6def4b87eae0ea591374ac825b369f).

The LLVM SPIR-V backend registers a `cl::opt` named `spirv-preserve-auxdata` after llvm/llvm-project#200002. This avoids the duplicate registration by deferring the translator's own option registration and renaming the backend's conflicting option when present.