### PR TITLE
Upstream merge 2026-06-19 09:30 EDT

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -79,10 +79,10 @@ void SPIRVToLLVMDbgTran::addDbgInfoVersion() {
 DIFile *
 SPIRVToLLVMDbgTran::getDIFile(const std::string &FileName,
                               std::optional<DIFile::ChecksumInfo<StringRef>> CS,
-                              std::optional<StringRef> Source) {
+                              std::optional<std::string> Source) {
   return getOrInsert(FileMap, FileName, [this, FileName, CS, Source]() {
     SplitFileName Split(FileName);
-    // Use the first builder from the map to crete DIFile since it's
+    // Use the first builder from the map to create DIFile since it's
     // relations with other debug metadata is not going through DICompileUnit
     if (!Split.BaseName.empty())
       return BuilderMap.begin()->second->createFile(Split.BaseName, Split.Path,
@@ -136,11 +136,11 @@ const std::string &SPIRVToLLVMDbgTran::getString(const SPIRVId Id) {
   return String->getStr();
 }
 
-const std::string
+std::optional<std::string>
 SPIRVToLLVMDbgTran::getStringSourceContinued(const SPIRVId Id,
                                              SPIRVExtInst *DebugInst) {
   if (!isValidId(Id) || getDbgInst<SPIRVDebug::DebugInfoNone>(Id))
-    return "";
+    return std::nullopt;
   std::string Str = BM->get<SPIRVString>(Id)->getStr();
   using namespace SPIRVDebug::Operand::SourceContinued;
   for (auto *I : DebugInst->getContinuedInstructions()) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -94,7 +94,7 @@ private:
   DIFile *
   getDIFile(const std::string &FileName,
             std::optional<DIFile::ChecksumInfo<StringRef>> CS = std::nullopt,
-            std::optional<StringRef> Source = std::nullopt);
+            std::optional<std::string> Source = std::nullopt);
   DIFile *getDIFile(const SPIRVEntry *E);
   unsigned getLineNo(const SPIRVEntry *E);
 
@@ -219,8 +219,8 @@ private:
     return nullptr;
   }
   const std::string &getString(const SPIRVId Id);
-  const std::string getStringSourceContinued(const SPIRVId Id,
-                                             SPIRVExtInst *DebugInst);
+  std::optional<std::string> getStringSourceContinued(const SPIRVId Id,
+                                                      SPIRVExtInst *DebugInst);
   SPIRVWord getConstantValueOrLiteral(const std::vector<SPIRVWord> &,
                                       const SPIRVWord,
                                       const SPIRVExtInstSetKind);

--- a/test/DebugInfo/DebugInfoChecksum.ll
+++ b/test/DebugInfo/DebugInfoChecksum.ll
@@ -47,6 +47,8 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 
 ; CHECK-LLVM: !DIFile(filename: "main.cpp"
 ; CHECK-LLVM-SAME: checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b"
+; The IR has no `source:` field; round-tripping must not introduce one.
+; CHECK-LLVM-NOT: source:
 
 ; CHECK-SPIRV-OCL: String [[#REG:]] "//__CSK_MD5:7bb56387968a9caa6e9e35fff94eaf7b"
 ; CHECK-SPIRV-OCL: DebugSource [[#]] [[#REG]]
@@ -55,7 +57,8 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 ; CHECK-SPIRV-200: String [[#Val:]] "7bb56387968a9caa6e9e35fff94eaf7b"
 ; CHECK-SPIRV-200: TypeInt [[#TypeInt32:]] 32
 ; CHECK-SPIRV-200: Constant [[#TypeInt32]] [[#Kind:]] 0
-; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]]
+; The DebugSource has File + ChecksumKind + ChecksumValue and nothing more.
+; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]] {{$}}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 7d09e1d7cf27ce781e83f9d388a7a3e1e6487ead)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
 !1 = !DIFile(filename: "<stdin>", directory: "oneAPI", checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b")

--- a/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
@@ -13,10 +13,7 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; ---- SPIR-V with extension ----
 ; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"

--- a/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
@@ -13,10 +13,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
@@ -9,10 +9,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
@@ -16,10 +16,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort.ll
@@ -6,10 +6,7 @@
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:

--- a/test/extensions/KHR/SPV_KHR_fma/fma.ll
+++ b/test/extensions/KHR/SPV_KHR_fma/fma.ll
@@ -1,6 +1,5 @@
 ; RUN: llvm-spirv %s --spirv-ext=+SPV_KHR_fma -o %t.spv
-; TODO: enable once spirv-val supports the extension.
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll

--- a/test/llvm-intrinsics/bitreverse_small_type.ll
+++ b/test/llvm-intrinsics/bitreverse_small_type.ll
@@ -22,9 +22,7 @@
 ; RUN: llvm-spirv -spirv-ext=+SPV_INTEL_arbitrary_precision_integers %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; TODO: There is no validation for SPV_INTEL_arbitrary_precision_integers implemented in
-; SPIRV-Tools. Enable after SPIR-V Tools are ready.
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: Name [[BR_2:[0-9]+]] "llvm_bitreverse_i2"
 ; CHECK-SPIRV: Name [[BR_4:[0-9]+]] "llvm_bitreverse_i4"

--- a/test/transcoding/OpenCL/math-builtins.ll
+++ b/test/transcoding/OpenCL/math-builtins.ll
@@ -12,8 +12,7 @@
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv %s -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
-; TODO: enable back once spirv-tools are updated
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM


### PR DESCRIPTION
Resolve conflict for merge of upstream KhronosGroup/SPIRV-LLVM-Translator main branch.

Merge this PR using "Create a merge commit" — do NOT squash.
Squash-merging destroys upstream ancestry tracking and will cause
conflicts on every future merge.

This PR was created automatically by the upstream-merge workflow.