### PR TITLE
[CI] Force LF checkout in Windows SPIRV CI

### DIFF
--- a/.github/workflows/spirv-ci-windows.yml
+++ b/.github/workflows/spirv-ci-windows.yml
@@ -23,9 +23,14 @@ jobs:
       llvm_project_sha: ${{ steps.resolve_llvm_sha.outputs.sha }}
 
     steps:
-      # Long path support for the deep llvm-project tree under runner workspace.
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       # Pinned ninja 1.12.1 — TheRock pins this version because 1.13.0 has a bug.
       - name: Install ninja
@@ -153,8 +158,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1
@@ -263,8 +274,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1
@@ -322,8 +339,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1


### PR DESCRIPTION
## Problem

The `Windows::release / Build` job in the SPIRV Compiler CI fails at clang's `check_format_depend_*` targets. These run `clang-format` on the clang `Format` library sources and `diff -u` the result against the on-disk files. The Git-for-Windows default checks files out with **CRLF**; `clang-format` emits **LF**, so `diff` flags every line and the build aborts.

## Fix

Set `core.autocrlf=false` and `core.eol=lf` (alongside the existing `core.longpaths`) before checkout in all four Windows jobs (`build`, `test_translator_lit`, `test_codegen`, `test_comgr`), so the working tree uses LF and matches Linux.

Ports the same fix as ROCm/llvm-project PR #3019 (`spirv-ci-windows-amd-staging.yml`), which these workflows are kept in sync with. The fix was validated there — the Windows build cleared the `check_format_depend_*` step that was previously failing.