### PR TITLE
[SPIRV] Fix YAML parse error breaking scheduled workflow runs

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -186,13 +186,7 @@ jobs:
           CONFLICT_FILES: ${{ steps.merge.outputs.conflict_files }}
           CONFLICT_COUNT: ${{ steps.merge.outputs.conflict_count }}
         run: |
-          python3 -c "
-import json, sys, urllib.request
-dt, files, count, run_url, url = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
-payload = {'\$schema': 'http://adaptivecards.io/schemas/adaptive-card.json', 'type': 'AdaptiveCard', 'version': '1.4', 'body': [{'type': 'TextBlock', 'text': '⚠️ Merge Conflicts Detected', 'weight': 'Bolder', 'size': 'Large', 'wrap': True}, {'type': 'FactSet', 'facts': [{'title': 'Time', 'value': dt}, {'title': 'Conflicting Files', 'value': f'{count} file(s)'}]}, {'type': 'TextBlock', 'text': f'Conflicting files:\n{files}', 'wrap': True}, {'type': 'TextBlock', 'text': f'[View workflow run]({run_url})', 'wrap': True}]}
-req = urllib.request.Request(url, json.dumps(payload).encode(), {'Content-Type': 'application/json'}, method='POST')
-with urllib.request.urlopen(req, timeout=30) as r: print(f'Teams HTTP {r.status}')
-" \
+          python3 -c "import json, sys, urllib.request; dt, files, count, run_url, url = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]; payload = {'\$schema': 'http://adaptivecards.io/schemas/adaptive-card.json', 'type': 'AdaptiveCard', 'version': '1.4', 'body': [{'type': 'TextBlock', 'text': '⚠️ Merge Conflicts Detected', 'weight': 'Bolder', 'size': 'Large', 'wrap': True}, {'type': 'FactSet', 'facts': [{'title': 'Time', 'value': dt}, {'title': 'Conflicting Files', 'value': f'{count} file(s)'}]}, {'type': 'TextBlock', 'text': f'Conflicting files:\n{files}', 'wrap': True}, {'type': 'TextBlock', 'text': f'[View workflow run]({run_url})', 'wrap': True}]}; req = urllib.request.Request(url, json.dumps(payload).encode(), {'Content-Type': 'application/json'}, method='POST'); r = urllib.request.urlopen(req, timeout=30); print(f'Teams HTTP {r.status}')" \
             "${{ steps.timestamp.outputs.datetime }}" \
             "$CONFLICT_FILES" \
             "${{ steps.merge.outputs.conflict_count }}" \


### PR DESCRIPTION
The python3 notification script in the "Notify Teams - Merge Conflict" step was written with literal newlines inside the `-c` string. This caused the Python code lines to appear at column 0 inside the YAML literal block scalar, which terminates the block early and produces a YAML parse error.

GitHub's workflow parser rejected the file, preventing all scheduled runs from firing since PR #241 merged on July 2.

## Fix

Collapse the multi-line Python to a single-line `-c` invocation using semicolons. All three statements fit on one line with no semantic change.

## Verification

File passes `python3 -c "import yaml; yaml.safe_load(open(...))"` cleanly.