### PR TITLE
[SPIRV][CI] Fix Windows build: disable vcpkg applocal, disable PCH

### DIFF
--- a/.github/workflows/spirv-ci-windows.yml
+++ b/.github/workflows/spirv-ci-windows.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
 
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
+
       - name: Checkout llvm-project (amd-staging)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -80,18 +83,27 @@ jobs:
       # zstd. FORCE_ON makes the configure fail loudly if zstd is missing
       # rather than silently building clang-offload-bundler without
       # compression.
+      # CMAKE_DISABLE_PRECOMPILE_HEADERS=ON: LLVM enables PCH by default, but the
+      # clang unit tests (built via clang-test-depends) reuse LLVMSupport's PCH.
+      # Upstream adds /utf-8 to the BasicTests target for unicode in test sources
+      # (llvm/llvm-project#206993); MSVC then rejects the PCH because its charset
+      # flags differ from the producer's (error C2855). Disabling PCH sidesteps
+      # this whole class of PCH consumer/producer flag-mismatch errors on MSVC.
+      # Mirrors ROCm/TheRock#6219, which disables PCH for the same reason (clang).
       - name: Configure LLVM
         run: |
           cmake -G Ninja -S llvm-project/llvm -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
             -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
             -DLLVM_ENABLE_ZSTD=FORCE_ON \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_INSTALL_GTEST=ON \
-            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build LLVM + Clang + amd-llvm-spirv + test deps
         run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv
@@ -109,6 +121,7 @@ jobs:
           cmake -G Ninja -S llvm-project/amd/device-libs -B build-device-libs \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DCMAKE_PREFIX_PATH=$PWD_WIN/build \
             -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm
 
@@ -121,6 +134,7 @@ jobs:
           cmake -G Ninja -S llvm-project/amd/comgr -B build-comgr \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DCMAKE_PREFIX_PATH="$PWD_WIN/build;$PWD_WIN/build-device-libs" \
             -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm \
             -DAMDDeviceLibs_DIR=$PWD_WIN/build-device-libs/lib/cmake/AMDDeviceLibs \
@@ -153,6 +167,8 @@ jobs:
     needs: build
     runs-on: azure-windows-scale-rocm
     timeout-minutes: 30
+    permissions:
+      contents: read
     defaults:
       run:
         shell: bash
@@ -178,6 +194,9 @@ jobs:
       # build-edge input that ninja validates at planning time.
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
+
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
 
       - name: Checkout llvm-project (pinned to Build job SHA)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -295,6 +314,9 @@ jobs:
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
 
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
+
       - name: Checkout llvm-project (pinned to Build job SHA)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -359,6 +381,9 @@ jobs:
       # build-edge input that ninja validates at planning time.
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
+
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
 
       - name: Checkout llvm-project (pinned to Build job SHA)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Problem

The `Windows::release / Build` job in the SPIRV Compiler CI fails intermittently. The real error is buried under vcpkg "deploying dependencies" spam; the single `FAILED:` per run is a file-lock on a chained `vcpkg z-applocal` step, on a **different target each run** (`llvm-sim.exe`, `XRayTests.exe`, `DebugInfoGSYMTests.exe`, `PipSqueak.dll`, …):

```
FAILED: bin/llvm-sim.exe
... link.exe ... && vcpkg z-applocal --target-binary=...llvm-sim.exe ...
Access is denied.
```

The vcpkg toolchain auto-enables `VCPKG_APPLOCAL_DEPS`, which adds a POST_BUILD `vcpkg z-applocal` step to **every** exe/dll target to copy `zstd.dll` next to it. Under ninja's parallelism those copies collide in shared output dirs → `Access is denied` / `being used by another process`.

## Fix

Ports the fixes already landed on `ROCm/llvm-project`'s sibling copy `spirv-ci-windows-amd-staging.yml` (#3232, #3170):

- Disable `VCPKG_APPLOCAL_DEPS` on all three cmake configures (LLVM, device-libs, comgr) to remove the copy race.
- Add `C:\vcpkg\installed\x64-windows\bin` to `PATH` in the build + test jobs so build-time tblgen and lit tools still resolve `zstd.dll` at runtime.
- Disable PCH (`CMAKE_DISABLE_PRECOMPILE_HEADERS=ON`) to avoid MSVC C2855 on clang unit tests once the build proceeds past applocal (same `ROCm/llvm-project amd-staging` source the sibling already hit C2855 on).
- Add least-privilege `permissions: contents: read` to the translator-lit test job.

The companion comgr test CMake fix (`ENVIRONMENT_MODIFICATION`) is already on `ROCm/llvm-project amd-staging`, which this CI checks out, so no port is needed here.

## Note

This must land on `amd-staging` before it takes effect on open merge PRs (e.g. #252): `pull_request` CI reads the workflow from the base branch. After merge, re-run the failed Windows job on those PRs.
