### PR TITLE
[CI] Build rocr-runtime and clr as Release in SPIRV Linux CI

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -144,6 +144,7 @@ jobs:
       - name: Configure ROCR-Runtime
         run: |
           cmake -G Ninja -S rocm-systems/projects/rocr-runtime -B "$ROCR_BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=$PWD/$LLVM_BUILD/bin/clang \
             -DCMAKE_CXX_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \
@@ -160,6 +161,7 @@ jobs:
       - name: Configure CLR (HIP runtime)
         run: |
           cmake -G Ninja -S rocm-systems/projects/clr -B "$CLR_BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=$PWD/$LLVM_BUILD/bin/clang \
             -DCMAKE_CXX_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
## Problem

The Linux SPIRV CI configures `rocr-runtime` and `clr` with **no `CMAKE_BUILD_TYPE`**, so CMake omits `-DNDEBUG`. That leaves debug-only code paths compiled in — e.g. rocr's `debug_print` macro, which is a no-op under `NDEBUG` but expands to real `fprintf(...)` otherwise.

This is why the CI hit `ROCm/rocm-systems#7502`'s regression (`arithmetic on a pointer to void` in `amd_core_dump.cpp`): the offending expressions only exist inside `debug_print` arguments, so they compile only in a non-`NDEBUG` build. Release builds — how rocr/clr actually ship — never compile them, which is why the regression didn't affect release consumers.

## Fix

Set `-DCMAKE_BUILD_TYPE=Release` on the `rocr-runtime` and `clr` configures. This matches the shipped configuration and stops the CI from compiling debug-only paths that release consumers never exercise. It also makes these runtime components build optimized rather than unoptimized.

## Notes

- Scope limited to the two rocm-systems runtime components. LLVM/comgr/device-libs are left as-is (comgr is the component under test; LLVM uses `LLVM_ENABLE_ASSERTIONS` deliberately) — those are a separate consideration.
- Independent of the upstream fix `ROCm/rocm-systems#8896`; either one unblocks the current Linux failure, but this prevents the whole class of debug-only breakage from unrelated rocm-systems churn.
