### PR TITLE
ci: fetch amd-staging baseline from canonical repo for fork PRs

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -383,7 +383,9 @@ jobs:
         if: always()
         run: |
           cd llvm-project/llvm/projects/SPIRV-LLVM-Translator
-          git fetch --depth=1 origin amd-staging
+          # Fetch from the canonical repo by URL, not `origin`: for fork PRs
+          # `origin` is the contributor's fork, which lacks amd-staging.
+          git fetch --depth=1 https://github.com/ROCm/SPIRV-LLVM-Translator amd-staging
           git checkout FETCH_HEAD
 
       - name: Test - SPIRV Translator [baseline amd-staging]

--- a/.github/workflows/spirv-ci-windows.yml
+++ b/.github/workflows/spirv-ci-windows.yml
@@ -244,7 +244,9 @@ jobs:
         if: always()
         run: |
           cd llvm-project/llvm/projects/SPIRV-LLVM-Translator
-          git fetch --depth=1 origin amd-staging
+          # Fetch from the canonical repo by URL, not `origin`: for fork PRs
+          # `origin` is the contributor's fork, which lacks amd-staging.
+          git fetch --depth=1 https://github.com/ROCm/SPIRV-LLVM-Translator amd-staging
           git checkout FETCH_HEAD
 
       - name: Test - SPIRV Translator [baseline amd-staging]


### PR DESCRIPTION
## Problem

The **Test SPIRV translator lit** job fails on PRs opened from a fork. The
"Switch translator to amd-staging tip for baseline" step runs:

```
git fetch --depth=1 origin amd-staging
```

For a fork PR, `actions/checkout` sets the translator's `origin` to the
contributor's fork, which has no `amd-staging` branch, so the fetch dies with
`fatal: couldn't find remote ref amd-staging` (exit 128) and fails the whole
job. Same-repo PRs are unaffected because there `origin` is this repo.

Example failure: https://github.com/ROCm/SPIRV-LLVM-Translator/actions/runs/29933046691/job/88974184844

## Fix

Fetch `amd-staging` from the canonical repo by explicit URL instead of relying
on `origin`, so the baseline swap works regardless of PR origin. This matches
the pattern already used in the `ROCm/llvm-project` copy of this workflow
(`git fetch --depth=1 https://github.com/ROCm/llvm-project.git amd-staging`).

Applied to both `spirv-ci-linux.yml` and `spirv-ci-windows.yml`.
