### PR TITLE
fix(ci): update gfx942 single-GPU runner label to ccs-csp

### DIFF
--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -57,7 +57,7 @@ jobs:
       linux_build_config: >-
         {
           "per_family_info": [
-            {"amdgpu_family": "gfx94X-dcgpu", "amdgpu_targets": "gfx942", "test-runs-on": "linux-gfx942-1gpu-ossci-rocm", "sanity_check_only_for_family": false},
+            {"amdgpu_family": "gfx94X-dcgpu", "amdgpu_targets": "gfx942", "test-runs-on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm", "sanity_check_only_for_family": false},
             {"amdgpu_family": "gfx110X-all", "amdgpu_targets": "", "test-runs-on": "", "sanity_check_only_for_family": true, "bypass_tests_for_releases": true},
             {"amdgpu_family": "gfx90a", "amdgpu_targets": "", "test-runs-on": "", "sanity_check_only_for_family": true, "bypass_tests_for_releases": true}
           ],

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -560,7 +560,7 @@ jobs:
   test_rocm_examples:
     name: Test rocm-examples
     needs: build
-    runs-on: linux-gfx942-1gpu-ossci-rocm
+    runs-on: linux-gfx942-1gpu-ccs-csp-ossci-rocm
     timeout-minutes: 45
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421


### PR DESCRIPTION
## Summary

- Updates `runs-on` in `spirv-ci-linux.yml` (test_rocm_examples job) from `linux-gfx942-1gpu-ossci-rocm` → `linux-gfx942-1gpu-ccs-csp-ossci-rocm`
- Updates `test-runs-on` for gfx94X-dcgpu in `setup_multi_arch.yml` matrix from `linux-gfx942-1gpu-ossci-rocm` → `linux-gfx942-1gpu-ccs-csp-ossci-rocm`

`linux-gfx942-1gpu-ossci-rocm` was the Vultr cluster single-GPU label, removed as part of the Vultr decommission in ROCm/therock-ci-config#21. Without this fix, the affected jobs will queue indefinitely with no runner to pick them up.

`linux-gfx942-1gpu-ccs-csp-ossci-rocm` is the current `test-runs-on` default for gfx94x in therock-ci-config.

## Test plan

- [ ] Confirm `test_rocm_examples` in spirv-ci-linux picks up a runner on next trigger
- [ ] Confirm gfx94X-dcgpu test jobs in setup_multi_arch pick up a runner on next trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)