### PR TITLE
Merge upstream/main into amd-staging (2026-07-30) + re-sync commented-out workflows

### DIFF
--- a/.github/workflows/backport-to-branch.yml
+++ b/.github/workflows/backport-to-branch.yml
@@ -1,186 +1,186 @@
-# name: Backport on Comment
+name: Backport on Comment
 
-# # Example use: /backport llvm_release_190
-# on:
-#   issue_comment:
-#     types: [created]
+# Example use: /backport llvm_release_190
+on:
+  issue_comment:
+    types: [created]
 
-# permissions:
-#   contents: write
-#   pull-requests: write
-#   issues: read
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
 
-# jobs:
-#   backport:
-#     if: >
-#       github.event.issue.pull_request != null &&
-#       startsWith(github.event.comment.body, '/backport ')
-#     runs-on: ubuntu-latest
+jobs:
+  backport:
+    if: >
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/backport ')
+    runs-on: ubuntu-latest
 
-    # steps:
-    #   - name: Checkout repository
-    #     uses: actions/checkout@v5
-    #     with:
-    #       fetch-depth: 0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-#       - name: Configure Git
-#         run: |
-#           git config user.name "${{ github.actor }}"
-#           git config user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-#       - name: Ensure PR is merged
-#         uses: actions/github-script@v7
-#         with:
-#           script: |
-#             const pr = await github.rest.pulls.get({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               pull_number: context.issue.number
-#             });
-#             if (!pr.data.merged) {
-#               core.setFailed('PR #' + context.issue.number + ' is not merged.');
-#             }
+      - name: Ensure PR is merged
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            if (!pr.data.merged) {
+              core.setFailed('PR #' + context.issue.number + ' is not merged.');
+            }
 
-#       - name: Parse backport command
-#         uses: actions/github-script@v7
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           result-encoding: string
-#           script: |
-#             const body = context.payload.comment.body.trim();
-#             const msg = body.match(/^\/backport\s+(llvm_release_[0-9]+)$/);
-#             if (!msg) {
-#               await github.rest.issues.createComment({
-#                 owner: context.repo.owner,
-#                 repo:  context.repo.repo,
-#                 issue_number: context.issue.number,
-#                 body: 'Invalid backport command. Expected `/backport llvm_release_<digits>`'
-#               });
-#               throw new Error('Invalid backport command.');
-#             }
-#             core.exportVariable('TARGET', msg[1]);
+      - name: Parse backport command
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const body = context.payload.comment.body.trim();
+            const msg = body.match(/^\/backport\s+(llvm_release_[0-9]+)$/);
+            if (!msg) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: context.issue.number,
+                body: 'Invalid backport command. Expected `/backport llvm_release_<digits>`'
+              });
+              throw new Error('Invalid backport command.');
+            }
+            core.exportVariable('TARGET', msg[1]);
 
-#       - name: Notify attempt
-#         uses: actions/github-script@v7
-#         with:
-#           script: |
-#             const target = process.env.TARGET;
-#             await github.rest.issues.createComment({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               issue_number: context.issue.number,
-#               body: `Attempting to create backport to \`${target}\`...`
-#             });
+      - name: Notify attempt
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const target = process.env.TARGET;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Attempting to create backport to \`${target}\`...`
+            });
 
-#       - name: Create backport branch
-#         run: |
-#           git fetch origin ${{ env.TARGET }}:${{ env.TARGET }}
-#           git checkout -b backport/pr-${{ github.event.issue.number }}-to-${{ env.TARGET }} origin/${{ env.TARGET }}
+      - name: Create backport branch
+        run: |
+          git fetch origin ${{ env.TARGET }}:${{ env.TARGET }}
+          git checkout -b backport/pr-${{ github.event.issue.number }}-to-${{ env.TARGET }} origin/${{ env.TARGET }}
 
-#       - name: Get commit sha
-#         id: merge_sha
-#         uses: actions/github-script@v7
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           result-encoding: string
-#           script: |
-#             const pr = await github.rest.pulls.get({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               pull_number: context.issue.number
-#             });
-#             // FIXME: handle PRs that are merged with "Rebase and Merge" strategy
-#             const sha = pr.data.merge_commit_sha;
-#             if (!sha) {
-#               throw new Error(`No merge_commit_sha found.`);
-#             }
-#             return sha;
+      - name: Get commit sha
+        id: merge_sha
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            // FIXME: handle PRs that are merged with "Rebase and Merge" strategy
+            const sha = pr.data.merge_commit_sha;
+            if (!sha) {
+              throw new Error(`No merge_commit_sha found.`);
+            }
+            return sha;
 
-#       - name: Cherry-pick commit
-#         id: cherry
-#         run: |
-#           conflict=false
-#           SHA="${{ steps.merge_sha.outputs.result }}"
-#           echo "Cherry-picking squash-merge commit $SHA"
-#           if git cherry-pick "$SHA"; then
-#             echo "Cherry-picked $SHA"
-#           else
-#             echo "Conflict on $SHA"
-#             conflict=true
-#             echo "CONFLICT_SHA=$SHA" >> $GITHUB_ENV
-#           fi
-#           echo "CONFLICT=$conflict" >> $GITHUB_ENV
+      - name: Cherry-pick commit
+        id: cherry
+        run: |
+          conflict=false
+          SHA="${{ steps.merge_sha.outputs.result }}"
+          echo "Cherry-picking squash-merge commit $SHA"
+          if git cherry-pick "$SHA"; then
+            echo "Cherry-picked $SHA"
+          else
+            echo "Conflict on $SHA"
+            conflict=true
+            echo "CONFLICT_SHA=$SHA" >> $GITHUB_ENV
+          fi
+          echo "CONFLICT=$conflict" >> $GITHUB_ENV
 
-#       - name: Notify conflict
-#         if: env.CONFLICT == 'true'
-#         uses: actions/github-script@v7
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           script: |
-#             const sha = process.env.CONFLICT_SHA;
-#             const target = process.env.TARGET;
-#             await github.rest.issues.createComment({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               issue_number: context.issue.number,
-#               body: `Backport to \`${target}\` failed due to conflicts on commit \`${sha}\`. Please backport manually.`
-#             });
+      - name: Notify conflict
+        if: env.CONFLICT == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sha = process.env.CONFLICT_SHA;
+            const target = process.env.TARGET;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Backport to \`${target}\` failed due to conflicts on commit \`${sha}\`. Please backport manually.`
+            });
 
-#       - name: Stop on conflict
-#         if: env.CONFLICT == 'true'
-#         run: exit 0
+      - name: Stop on conflict
+        if: env.CONFLICT == 'true'
+        run: exit 0
 
-#       - name: Push backport branch
-#         if: env.CONFLICT == 'false'
-#         run: git push --set-upstream origin HEAD
+      - name: Push backport branch
+        if: env.CONFLICT == 'false'
+        run: git push --set-upstream origin HEAD
 
-#       - name: Prepare PR
-#         if: env.CONFLICT == 'false'
-#         id: prinfo
-#         run: |
-#           echo "BODY<<EOF" >> $GITHUB_ENV
-#           echo "Backport of PR #${{ github.event.issue.number }} into \`${{ env.TARGET }}\`." >> $GITHUB_ENV
-#           echo "" >> $GITHUB_ENV
-#           echo "All commits applied cleanly." >> $GITHUB_ENV
-#           echo "EOF" >> $GITHUB_ENV
-#           echo "LABELS=backport" >> $GITHUB_ENV
+      - name: Prepare PR
+        if: env.CONFLICT == 'false'
+        id: prinfo
+        run: |
+          echo "BODY<<EOF" >> $GITHUB_ENV
+          echo "Backport of PR #${{ github.event.issue.number }} into \`${{ env.TARGET }}\`." >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "All commits applied cleanly." >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "LABELS=backport" >> $GITHUB_ENV
 
-#       - name: Create Pull Request
-#         if: env.CONFLICT == 'false'
-#         id: create_pr
-#         uses: actions/github-script@v7
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           result-encoding: string
-#           script: |
-#             const {data: pr} = await github.rest.pulls.create({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               head: `backport/pr-${context.issue.number}-to-${process.env.TARGET}`,
-#               base: process.env.TARGET,
-#               title: `[Backport to ${process.env.TARGET}] ${context.payload.issue.title}`,
-#               body: process.env.BODY
-#             });
-#             return pr.html_url;
+      - name: Create Pull Request
+        if: env.CONFLICT == 'false'
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const {data: pr} = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `backport/pr-${context.issue.number}-to-${process.env.TARGET}`,
+              base: process.env.TARGET,
+              title: `[Backport to ${process.env.TARGET}] ${context.payload.issue.title}`,
+              body: process.env.BODY
+            });
+            return pr.html_url;
 
-#       - name: Notify success
-#         if: env.CONFLICT == 'false'
-#         uses: actions/github-script@v7
-#         env:
-#           PR_URL: ${{ steps.create_pr.outputs.result }}
-#         with:
-#           script: |
-#             const target = process.env.TARGET;
-#             await github.rest.issues.createComment({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               issue_number: context.issue.number,
-#               body: `Success. Backport PR created: ${process.env.PR_URL}`
-#             });
+      - name: Notify success
+        if: env.CONFLICT == 'false'
+        uses: actions/github-script@v7
+        env:
+          PR_URL: ${{ steps.create_pr.outputs.result }}
+        with:
+          script: |
+            const target = process.env.TARGET;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Success. Backport PR created: ${process.env.PR_URL}`
+            });
 
-#       - name: Notify workflows
-#         if: env.CONFLICT == 'false'
-#         uses: peter-evans/repository-dispatch@v3
-#         with:
-#           token: ${{ secrets.GITHUB_TOKEN }}
-#           event-type: backport-complete
+      - name: Notify workflows
+        if: env.CONFLICT == 'false'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: backport-complete

--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -91,7 +91,8 @@ jobs:
       if: ${{ steps.gather-list-of-changes.outputs.HAS_CHANGES }}
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} \
+        cmake -DBASE_LLVM_VERSION=23.0.0 \
+            -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ${{ github.workspace }}
 
     - name: Run clang-format

--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,88 +1,88 @@
-# name: Automated release
+name: Automated release
 
-# on:
-#   workflow_dispatch:
-#   schedule:
-#     # First day of every month
-#     - cron: '0 0 1 * *'
+on:
+  workflow_dispatch:
+  schedule:
+    # First day of every month
+    - cron: '0 0 1 * *'
 
-# jobs:
-#   setup:
-#     runs-on: ubuntu-latest
-#     outputs:
-#       latest_branch: ${{steps.latest_branch.outputs.latest_branch}}
-#       branches_json: ${{steps.release_branches.outputs.branches_json}}
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v5
-#         with:
-#             fetch-depth: 0
-#       - name: Get latest llvm_release branch
-#         id: latest_branch
-#         run: |
-#           git branch -r \
-#           | grep 'llvm_release_' \
-#           | sed -E 's/.*\/llvm_release_([0-9]+)/\1/' \
-#           | sort -n -r \
-#           | head -1 \
-#           | xargs printf "latest_branch=llvm_release_%s" \
-#           >> $GITHUB_OUTPUT
-#       - name: Get branch list
-#         id: release_branches
-#         run: |
-#           git branch -r \
-#           | grep "origin/llvm_release_" \
-#           | sed -E 's/\ *origin\/([^\ ]*)/\"\1\"/' \
-#           | paste -sd',' \
-#           | xargs -0 -d"\n" printf 'branches_json={"branch":[%s]}' \
-#           >> $GITHUB_OUTPUT
-#   release:
-#     runs-on: ubuntu-latest
-#     needs: setup
-#     strategy:
-#       matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v5
-#         with:
-#             ref: ${{ matrix.branch }}
-#             fetch-depth: 0
-#       - name: Get commits info
-#         id: versions
-#         run: |
-#             export LATEST_VERSION=\
-#             "$(git describe --tags --abbrev=0 --match 'v*')"
-#             export LLVM_VERSION=$(echo $LATEST_VERSION \
-#             | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\1/')
-#             export PATCH=$(echo $LATEST_VERSION \
-#             | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\2/')
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_branch: ${{steps.latest_branch.outputs.latest_branch}}
+      branches_json: ${{steps.release_branches.outputs.branches_json}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+            fetch-depth: 0
+      - name: Get latest llvm_release branch
+        id: latest_branch
+        run: |
+          git branch -r \
+          | grep 'llvm_release_' \
+          | sed -E 's/.*\/llvm_release_([0-9]+)/\1/' \
+          | sort -n -r \
+          | head -1 \
+          | xargs printf "latest_branch=llvm_release_%s" \
+          >> $GITHUB_OUTPUT
+      - name: Get branch list
+        id: release_branches
+        run: |
+          git branch -r \
+          | grep "origin/llvm_release_" \
+          | sed -E 's/\ *origin\/([^\ ]*)/\"\1\"/' \
+          | paste -sd',' \
+          | xargs -0 -d"\n" printf 'branches_json={"branch":[%s]}' \
+          >> $GITHUB_OUTPUT
+  release:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+            ref: ${{ matrix.branch }}
+            fetch-depth: 0
+      - name: Get commits info
+        id: versions
+        run: |
+            export LATEST_VERSION=\
+            "$(git describe --tags --abbrev=0 --match 'v*')"
+            export LLVM_VERSION=$(echo $LATEST_VERSION \
+            | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\1/')
+            export PATCH=$(echo $LATEST_VERSION \
+            | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\2/')
 
-#             echo "llvm_version=$LLVM_VERSION" >> $GITHUB_OUTPUT
-#             echo "patch=$PATCH" >> $GITHUB_OUTPUT
-#             echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
-#             echo "release_version=${LLVM_VERSION}.$((${PATCH}+1))" \
-#             >> $GITHUB_OUTPUT
+            echo "llvm_version=$LLVM_VERSION" >> $GITHUB_OUTPUT
+            echo "patch=$PATCH" >> $GITHUB_OUTPUT
+            echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            echo "release_version=${LLVM_VERSION}.$((${PATCH}+1))" \
+            >> $GITHUB_OUTPUT
 
-#             git rev-list ${LATEST_VERSION}..HEAD --count \
-#             | xargs printf "commits_since_last_release=%d\n" >> $GITHUB_OUTPUT
-#             git rev-parse HEAD | xargs printf "last_commit=%s\n" >> $GITHUB_OUTPUT
-#       - name: Release
-#         uses: softprops/action-gh-release@v2
-#         if: ${{ steps.versions.outputs.commits_since_last_release != 0 }}
-#         with:
-#             # Setting tag to have format:
-#             # %latest llvm version%.%latest patch + 1%
-#             tag_name: ${{ steps.versions.outputs.release_version }}
-#             # We have to set this so tag is set on the branch we are releasing
-#             target_commitish: ${{ steps.versions.outputs.last_commit }}
-#             # We don't want to mark patch releases latest unless it is latest
-#             # major version
-#             make_latest: >-
-#               ${{ needs.setup.outputs.latest_branch == matrix.branch }}
-#             name: >
-#               SPIR-V LLVM translator based on LLVM
-#               ${{ steps.versions.outputs.llvm_version }}
-#             body: "Full Changelog: ${{ github.server_url }}/\
-#               ${{ github.repository }}/compare/\
-#               ${{ steps.versions.outputs.latest_version }}...\
-#               ${{ steps.versions.outputs.release_version }}"
+            git rev-list ${LATEST_VERSION}..HEAD --count \
+            | xargs printf "commits_since_last_release=%d\n" >> $GITHUB_OUTPUT
+            git rev-parse HEAD | xargs printf "last_commit=%s\n" >> $GITHUB_OUTPUT
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ steps.versions.outputs.commits_since_last_release != 0 }}
+        with:
+            # Setting tag to have format:
+            # %latest llvm version%.%latest patch + 1%
+            tag_name: ${{ steps.versions.outputs.release_version }}
+            # We have to set this so tag is set on the branch we are releasing
+            target_commitish: ${{ steps.versions.outputs.last_commit }}
+            # We don't want to mark patch releases latest unless it is latest
+            # major version
+            make_latest: >-
+              ${{ needs.setup.outputs.latest_branch == matrix.branch }}
+            name: >
+              SPIR-V LLVM translator based on LLVM
+              ${{ steps.versions.outputs.llvm_version }}
+            body: "Full Changelog: ${{ github.server_url }}/\
+              ${{ github.repository }}/compare/\
+              ${{ steps.versions.outputs.latest_version }}...\
+              ${{ steps.versions.outputs.release_version }}"

--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -304,12 +304,10 @@ public:
 };
 
 class OCLToSPIRVPass : public OCLToSPIRVBase,
-                       public llvm::PassInfoMixin<OCLToSPIRVPass> {
+                       public llvm::RequiredPassInfoMixin<OCLToSPIRVPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/PreprocessMetadata.h
+++ b/lib/SPIRV/PreprocessMetadata.h
@@ -78,13 +78,11 @@ public:
 };
 
 class PreprocessMetadataPass
-    : public llvm::PassInfoMixin<PreprocessMetadataPass>,
+    : public llvm::RequiredPassInfoMixin<PreprocessMetadataPass>,
       public PreprocessMetadataBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -156,6 +156,7 @@ typedef SPIRVMap<CmpInst::Predicate, Op> CmpMap;
 class IntBoolOpMapId;
 template <> inline void SPIRVMap<Op, Op, IntBoolOpMapId>::init() {
   add(OpNot, OpLogicalNot);
+  add(OpIMul, OpLogicalAnd);
   add(OpBitwiseAnd, OpLogicalAnd);
   add(OpBitwiseOr, OpLogicalOr);
   add(OpBitwiseXor, OpLogicalNotEqual);

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
@@ -43,15 +43,14 @@
 namespace SPIRV {
 
 class SPIRVLowerBitCastToNonStandardTypePass
-    : public llvm::PassInfoMixin<SPIRVLowerBitCastToNonStandardTypePass> {
+    : public llvm::RequiredPassInfoMixin<
+          SPIRVLowerBitCastToNonStandardTypePass> {
 public:
   SPIRVLowerBitCastToNonStandardTypePass(const SPIRV::TranslatorOpts &Opts)
       : Opts(Opts) {}
 
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &FAM);
-
-  static bool isRequired() { return true; }
 
 private:
   SPIRV::TranslatorOpts Opts;

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -99,8 +99,9 @@ void SPIRVLowerBoolBase::handleCastInstructions(Instruction &I) {
     Type *Ty = Type::getInt32Ty(*Context);
     if (auto *VT = dyn_cast<FixedVectorType>(OpTy))
       Ty = llvm::FixedVectorType::get(Ty, VT->getNumElements());
+    bool IsSigned = I.getOpcode() == Instruction::SIToFP;
     auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-    auto *One = getScalarOrVectorConstantInt(Ty, 1, false);
+    auto *One = getScalarOrVectorConstantInt(Ty, IsSigned ? ~0 : 1, IsSigned);
     assert(Zero && One && "Couldn't create constant int");
     auto *Sel = SelectInst::Create(Op, One, Zero, "", I.getIterator());
     Sel->setDebugLoc(I.getDebugLoc());

--- a/lib/SPIRV/SPIRVLowerBool.h
+++ b/lib/SPIRV/SPIRVLowerBool.h
@@ -65,13 +65,12 @@ private:
   llvm::LLVMContext *Context;
 };
 
-class SPIRVLowerBoolPass : public llvm::PassInfoMixin<SPIRVLowerBoolPass>,
-                           public SPIRVLowerBoolBase {
+class SPIRVLowerBoolPass
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerBoolPass>,
+      public SPIRVLowerBoolBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerBoolLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerConstExpr.h
+++ b/lib/SPIRV/SPIRVLowerConstExpr.h
@@ -36,7 +36,7 @@ private:
 };
 
 class SPIRVLowerConstExprPass
-    : public llvm::PassInfoMixin<SPIRVLowerConstExprPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerConstExprPass>,
       public SPIRVLowerConstExprBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -44,8 +44,6 @@ public:
     return runLowerConstExpr(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVLowerLLVMIntrinsic.h
+++ b/lib/SPIRV/SPIRVLowerLLVMIntrinsic.h
@@ -62,14 +62,12 @@ private:
 };
 
 class SPIRVLowerLLVMIntrinsicPass
-    : public llvm::PassInfoMixin<SPIRVLowerLLVMIntrinsicPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerLLVMIntrinsicPass>,
       public SPIRVLowerLLVMIntrinsicBase {
 public:
   SPIRVLowerLLVMIntrinsicPass(const SPIRV::TranslatorOpts &Opts);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerLLVMIntrinsicLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerMemmove.h
+++ b/lib/SPIRV/SPIRVLowerMemmove.h
@@ -58,13 +58,12 @@ private:
   llvm::LLVMContext *Context;
 };
 
-class SPIRVLowerMemmovePass : public llvm::PassInfoMixin<SPIRVLowerMemmovePass>,
-                              public SPIRVLowerMemmoveBase {
+class SPIRVLowerMemmovePass
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerMemmovePass>,
+      public SPIRVLowerMemmoveBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerMemmoveLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.h
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.h
@@ -48,13 +48,11 @@ public:
 };
 
 class SPIRVLowerOCLBlocksPass
-    : public llvm::PassInfoMixin<SPIRVLowerOCLBlocksPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerOCLBlocksPass>,
       public SPIRVLowerOCLBlocksBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerOCLBlocksLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2480,7 +2480,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       return mapValue(BV, transSPIRVBuiltinFromInst(AC, BB));
     }
     Type *BaseTy = nullptr;
-    if (BaseSPVTy->isTypeVector()) {
+    if (isUntypedAccessChainOpCode(OC)) {
+      // For untyped access chains the Base Type operand already is the type
+      // being indexed, so it has to be used as is.
+      BaseTy = transType(BaseSPVTy);
+    } else if (BaseSPVTy->isTypeVector()) {
       auto *VecCompTy = BaseSPVTy->getVectorComponentType();
       if (VecCompTy->isTypePointer())
         BaseTy = transType(VecCompTy->getPointerElementType());

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -122,7 +122,7 @@ private:
 };
 
 class SPIRVRegularizeLLVMPass
-    : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVRegularizeLLVMPass>,
       public SPIRVRegularizeLLVMBase {
 public:
   explicit SPIRVRegularizeLLVMPass(const SPIRV::TranslatorOpts &Opts = {})
@@ -133,8 +133,6 @@ public:
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -383,7 +383,7 @@ public:
   std::string mapAtomicName(Op OC, Type *Ty);
 };
 
-class SPIRVToOCL12Pass : public llvm::PassInfoMixin<SPIRVToOCL12Pass>,
+class SPIRVToOCL12Pass : public llvm::RequiredPassInfoMixin<SPIRVToOCL12Pass>,
                          public SPIRVToOCL12Base {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -391,8 +391,6 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL12Legacy : public SPIRVToOCL12Base, public SPIRVToOCLLegacy {
@@ -456,7 +454,7 @@ public:
   void visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
 };
 
-class SPIRVToOCL20Pass : public llvm::PassInfoMixin<SPIRVToOCL20Pass>,
+class SPIRVToOCL20Pass : public llvm::RequiredPassInfoMixin<SPIRVToOCL20Pass>,
                          public SPIRVToOCL20Base {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -464,8 +462,6 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL20Legacy : public SPIRVToOCLLegacy, public SPIRVToOCL20Base {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4153,6 +4153,7 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::round:
   case Intrinsic::roundeven:
   case Intrinsic::sin:
+  case Intrinsic::sincos:
   case Intrinsic::sqrt:
   case Intrinsic::tan:
   case Intrinsic::trunc:
@@ -4565,6 +4566,32 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     // Create the struct.
     SPIRVType *STy = transType(II->getType());
     std::vector<SPIRVId> StructVals{Modf->getId(), IntegralVal->getId()};
+    return BM->addCompositeConstructInst(STy, StructVals, BB);
+  }
+  case Intrinsic::sincos: {
+    // llvm.sincos(x) returns {sin(x), cos(x)}, while OpenCLLIB::Sincos takes
+    // (x, cos_ptr) and returns sin(x), storing cos(x) via the pointer.
+    // Create a temporary function variable for the cos output, call OpenCL
+    // sincos, load the cos value, then construct the result struct.
+    SPIRVType *CosTy = transType(II->getType()->getStructElementType(1));
+    SPIRVType *CosPtrTy = BM->addPointerType(StorageClassFunction, CosTy);
+    SPIRVBasicBlock *EntryBB = BB->getParent()->getBasicBlock(0);
+    SPIRVValue *CosPtr =
+        BM->addVariable(static_cast<SPIRVTypePointer *>(CosPtrTy), nullptr,
+                        false, spv::internal::LinkageTypeInternal, nullptr, "",
+                        StorageClassFunction, EntryBB);
+
+    SPIRVType *SinTy = transType(II->getType()->getStructElementType(0));
+    SPIRVValue *Arg = transValue(II->getArgOperand(0), BB);
+    std::vector<SPIRVValue *> Ops{Arg, CosPtr};
+    SPIRVValue *SinVal =
+        BM->addExtInst(SinTy, BM->getExtInstSetId(SPIRVEIS_OpenCL),
+                       OpenCLLIB::Sincos, Ops, BB);
+
+    SPIRVValue *CosVal = BM->addLoadInst(CosPtr, {}, BB, CosTy);
+
+    SPIRVType *STy = transType(II->getType());
+    std::vector<SPIRVId> StructVals{SinVal->getId(), CosVal->getId()};
     return BM->addCompositeConstructInst(STy, StructVals, BB);
   }
   // Binary FP intrinsics

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3275,7 +3275,8 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
       (isa<AtomicRMWInst>(V) && cast<AtomicRMWInst>(V)->isVolatile()))
     BV->setVolatile(true);
 
-  if (auto *BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V)) {
+  if (auto *BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V);
+      BVO && !BVO->getType()->isIntOrIntVectorTy(1)) {
     if (BVO->hasNoSignedWrap()) {
       BV->setNoIntegerDecorationWrap<DecorationNoSignedWrap>(true);
     }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -964,7 +964,8 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
           SPIRVEC_RequiresExtension, "SPV_KHR_uniform_group_instructions\n");
     BM->setName(BF, F->getName().str());
   }
-  if (!isKernel(F) && F->getLinkage() != GlobalValue::InternalLinkage)
+  if (!isKernel(F) && F->hasName() &&
+      F->getLinkage() != GlobalValue::InternalLinkage)
     BF->setLinkageType(transLinkageType(F));
 
   // Translate OpenCL/SYCL buffer_location metadata if it's attached to the
@@ -6496,6 +6497,8 @@ void LLVMToSPIRVBase::transFunction(Function *I) {
   fpContractUpdateRecursive(I, getFPContract(I));
 
   if (isKernel(I)) {
+    BM->getErrorLog().checkError(I->hasName(), SPIRVEC_InvalidLlvmModule,
+                                 "Entry point function must have a name");
     auto Interface = collectEntryPointInterfaces(BF, I);
     BM->addEntryPoint(ExecutionModelKernel, BF->getId(), I->getName().str(),
                       Interface);

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -270,7 +270,7 @@ private:
                                                    Function *F);
 };
 
-class LLVMToSPIRVPass : public PassInfoMixin<LLVMToSPIRVPass> {
+class LLVMToSPIRVPass : public RequiredPassInfoMixin<LLVMToSPIRVPass> {
 public:
   LLVMToSPIRVPass(SPIRVModule *SMod) : SMod(SMod) {}
 
@@ -281,8 +281,6 @@ public:
     return PassInstance.runLLVMToSPIRV(M) ? llvm::PreservedAnalyses::none()
                                           : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 
 private:
   SPIRVModule *SMod;

--- a/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_ptr_access_chain_vector_base.spt
+++ b/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_ptr_access_chain_vector_base.spt
@@ -1,0 +1,43 @@
+; The Base Type operand of an untyped access chain is the type being indexed,
+; not a pointer to it, so it must be used as is.
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: %[[#GEP:]] = getelementptr inbounds <4 x float>, ptr addrspace(1) %{{.*}}, i64 %{{.*}}
+; CHECK-LLVM-NEXT: load <4 x float>, ptr addrspace(1) %[[#GEP]], align 16
+
+119734787 67072 458752 14 0
+2 Capability Addresses
+2 Capability Kernel
+2 Capability Int64
+2 Capability UntypedPointersKHR
+8 Extension "SPV_KHR_untyped_pointers"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2
+5 EntryPoint 6 2 "test"
+3 Source 3 102000
+3 Name 3 "p"
+3 Name 4 "idx"
+
+4 TypeInt 6 64 0
+2 TypeVoid 5
+3 TypeFloat 7 32
+4 TypeVector 8 7 4
+3 TypeUntypedPointerKHR 9 5
+5 TypeFunction 10 5 9 6
+
+5 Function 5 2 0 10
+3 FunctionParameter 9 3
+3 FunctionParameter 6 4
+
+2 Label 11
+6 UntypedInBoundsPtrAccessChainKHR 9 12 8 3 4
+6 Load 8 13 12 2 16
+5 Store 3 13 2 16
+1 Return
+
+1 FunctionEnd
+

--- a/test/link-attribute-numeric-name.ll
+++ b/test/link-attribute-numeric-name.ll
@@ -1,0 +1,20 @@
+; RUN: llvm-spirv %s -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; A numeric-named function has no meaningful linkage name, so no
+; LinkageAttributes decoration should be emitted for it.
+; CHECK-NOT: LinkageAttributes
+
+define spir_func void @0() {
+  ret void
+}
+
+define spir_kernel void @kernel() {
+  call spir_func void @0()
+  ret void
+}

--- a/test/llvm-intrinsics/fp-intrinsics.ll
+++ b/test/llvm-intrinsics/fp-intrinsics.ll
@@ -508,3 +508,20 @@ entry:
 }
 
 declare float @llvm.ldexp.f32.i32(float, i32)
+
+; CHECK: Function [[ResTy2:[0-9]+]]
+; CHECK: FunctionParameter {{[0-9]+}} [[xsincos:[0-9]+]]
+; CHECK: Variable [[PtrTy2:[0-9]+]] [[CosPtr:[0-9]+]] 7
+; CHECK: ExtInst [[var2]] [[SinVal:[0-9]+]] [[extinst_id]] sincos [[xsincos]] [[CosPtr]]
+; CHECK: Load [[var2]] [[CosVal:[0-9]+]] [[CosPtr]]
+; CHECK: CompositeConstruct [[ResTy2]] [[RetVal2:[0-9]+]] [[SinVal]] [[CosVal]]
+; CHECK: ReturnValue [[RetVal2]]
+; CHECK: FunctionEnd
+
+define spir_func {double, double} @TestSincos(double %x) {
+entry:
+  %t = tail call {double, double} @llvm.sincos.f64(double %x)
+  ret {double, double} %t
+}
+
+declare {double, double} @llvm.sincos.f64(double)

--- a/test/negative/nameless-kernel-error.ll
+++ b/test/negative/nameless-kernel-error.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-spirv %s -o %t.spv 2>&1 | FileCheck %s
+
+; CHECK: InvalidLlvmModule: Invalid LLVM module: Entry point function must have a name
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @0() {
+  ret void
+}

--- a/test/sitofp-with-bool.ll
+++ b/test/sitofp-with-bool.ll
@@ -5,14 +5,14 @@
 
 ; CHECK: TypeInt [[int_32:[0-9]+]] 32 0
 ; CHECK: Constant  {{[0-9]+}} [[zero:[0-9]+]] 0
-; CHECK: Constant  {{[0-9]+}} [[one:[0-9]+]] 1
+; CHECK: Constant  {{[0-9]+}} [[mone:[0-9]+]] 4294967295
 ; CHECK: TypeBool [[bool:[0-9]+]]
 
 ; CHECK: Function
 ; CHECK: FunctionParameter {{[0-9]+}} [[A:[0-9]+]]
 ; CHECK: FunctionParameter {{[0-9]+}} [[B:[0-9]+]]
 ; CHECK: SGreaterThan [[bool]] [[cmp_res:[0-9]+]] [[B]] [[zero]]
-; CHECK: Select [[int_32]] [[select_res:[0-9]+]] [[cmp_res]] [[one]] [[zero]]
+; CHECK: Select [[int_32]] [[select_res:[0-9]+]] [[cmp_res]] [[mone]] [[zero]]
 ; CHECK: ConvertSToF {{[0-9]+}} [[stof_res:[0-9]+]] [[select_res]]
 ; CHECK: Store [[A]] [[stof_res]]
 

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -7,8 +7,6 @@
 // RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV
 // RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-//
-// XFAIL: *
 
 // CHECK-SPIRV: TypeDeviceEvent
 // CHECK-SPIRV: 5 Function
@@ -21,20 +19,20 @@
 // CHECK-SPIRV: FunctionEnd
 
 // CHECK-LLVM-OCL-LABEL: @clk_event_t_test
-// CHECK-LLVM-OCL: call spir_func ptr @_Z17create_user_eventv()
+// CHECK-LLVM-OCL: call spir_func target("spirv.DeviceEvent") @_Z17create_user_eventv()
 // CHECK-LLVM-OCL: call spir_func i1 @_Z14is_valid_event12ocl_clkevent(
 // CHECK-LLVM-OCL: call spir_func void @_Z12retain_event12ocl_clkevent(
-// CHECK-LLVM-OCL: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(ptr %{{[a-z]+}}, i32 -42)
-// CHECK-LLVM-OCL: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(ptr %{{[a-z]+}}, i32 1, ptr addrspace(1) %prof)
+// CHECK-LLVM-OCL: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(target("spirv.DeviceEvent") %{{[a-z]+}}, i32 -42)
+// CHECK-LLVM-OCL: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(target("spirv.DeviceEvent") %{{[a-z]+}}, i32 1, ptr addrspace(1) %prof)
 // CHECK-LLVM-OCL: call spir_func void @_Z13release_event12ocl_clkevent(
 // CHECK-LLVM-OCL: ret
 
 // CHECK-LLVM-SPV-LABEL: @clk_event_t_test
-// CHECK-LLVM-SPV: call spir_func ptr @_Z23__spirv_CreateUserEventv()
+// CHECK-LLVM-SPV: call spir_func target("spirv.DeviceEvent") @_Z23__spirv_CreateUserEventv()
 // CHECK-LLVM-SPV: call spir_func i1 @_Z20__spirv_IsValidEventP19__spirv_DeviceEvent(
 // CHECK-LLVM-SPV: call spir_func void @_Z19__spirv_RetainEventP19__spirv_DeviceEvent(
-// CHECK-LLVM-SPV: call spir_func void @_Z26__spirv_SetUserEventStatusP19__spirv_DeviceEventi(ptr %{{[a-z]+}}, i32 -42)
-// CHECK-LLVM-SPV: call spir_func void @_Z33__spirv_CaptureEventProfilingInfoP19__spirv_DeviceEventiPU3AS1c(ptr %{{[a-z]+}}, i32 1, ptr addrspace(1) %prof)
+// CHECK-LLVM-SPV: call spir_func void @_Z26__spirv_SetUserEventStatusP19__spirv_DeviceEventi(target("spirv.DeviceEvent") %{{[a-z]+}}, i32 -42)
+// CHECK-LLVM-SPV: call spir_func void @_Z33__spirv_CaptureEventProfilingInfoP19__spirv_DeviceEventiPU3AS1c(target("spirv.DeviceEvent") %{{[a-z]+}}, i32 1, ptr addrspace(1) %prof)
 // CHECK-LLVM-SPV: call spir_func void @_Z20__spirv_ReleaseEventP19__spirv_DeviceEvent(
 // CHECK-LLVM-SPV: ret
 

--- a/test/transcoding/mul_i1.ll
+++ b/test/transcoding/mul_i1.ll
@@ -1,0 +1,51 @@
+; Multiplication of two boolean values must be translated to OpLogicalAnd,
+; since OpIMul requires integer operands and OpTypeBool is not an integer type.
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-NOT: IMul
+
+define spir_func i1 @bool_mul(i1 %a, i1 %b) {
+  %c = mul i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A1:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B1:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A1]] [[B1]]
+; CHECK-LLVM: define spir_func i1 @bool_mul(i1 [[A1:%[a-zA-Z0-9_.]+]], i1 [[B1:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A1]], [[B1]]
+
+define spir_func i1 @bool_mul_nsw(i1 %a, i1 %b) {
+  %c = mul nsw i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A2:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B2:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A2]] [[B2]]
+; CHECK-LLVM: define spir_func i1 @bool_mul_nsw(i1 [[A2:%[a-zA-Z0-9_.]+]], i1 [[B2:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A2]], [[B2]]
+
+define spir_func i1 @bool_mul_nuw(i1 %a, i1 %b) {
+  %c = mul nuw i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A3:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B3:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A3]] [[B3]]
+; CHECK-LLVM: define spir_func i1 @bool_mul_nuw(i1 [[A3:%[a-zA-Z0-9_.]+]], i1 [[B3:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A3]], [[B3]]
+
+define spir_func <4 x i1> @vec_bool_mul(<4 x i1> %a, <4 x i1> %b) {
+  %c = mul <4 x i1> %a, %b
+  ret <4 x i1> %c
+}
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A4:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B4:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A4]] [[B4]]
+; CHECK-LLVM: define spir_func <4 x i1> @vec_bool_mul(<4 x i1> [[A4:%[a-zA-Z0-9_.]+]], <4 x i1> [[B4:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and <4 x i1> [[A4]], [[B4]]

--- a/test/uitofp-with-bool.ll
+++ b/test/uitofp-with-bool.ll
@@ -160,14 +160,14 @@ entry:
 ; LLVM-DAG: %[[ufp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %ufp2 = uitofp <2 x i32> %[[ufp2_res_llvm]] to <2 x float>
   %ufp2 = uitofp <2 x i1> %i1v to <2 x float>
-; SPV-DAG: Select [[int_32]] [[sfp1_res:[0-9]+]] [[i1s]] [[one_32]] [[zero_32]]
+; SPV-DAG: Select [[int_32]] [[sfp1_res:[0-9]+]] [[i1s]] [[mone_32]] [[zero_32]]
 ; SPV-DAG: ConvertSToF [[float]] [[sfp1]] [[sfp1_res]]
-; LLVM-DAG: %[[sfp1_res_llvm:[0-9]+]] = select i1 %i1s, i32 1, i32 0
+; LLVM-DAG: %[[sfp1_res_llvm:[0-9]+]] = select i1 %i1s, i32 -1, i32 0
 ; LLVM-DAG: %sfp1 = sitofp i32 %[[sfp1_res_llvm:[0-9]+]] to float
   %sfp1 = sitofp i1 %i1s to float
-; SPV-DAG: Select [[vec_32]] [[sfp2_res:[0-9]+]] [[i1v]] [[ones_32]] [[zeros_32]]
+; SPV-DAG: Select [[vec_32]] [[sfp2_res:[0-9]+]] [[i1v]] [[mones_32]] [[zeros_32]]
 ; SPV-DAG: ConvertSToF [[vec_float]] [[sfp2]] [[sfp2_res]]
-; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
+; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 -1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %sfp2 = sitofp <2 x i32> %[[sfp2_res_llvm]] to <2 x float>
   %sfp2 = sitofp <2 x i1> %i1v to <2 x float>
   ret void


### PR DESCRIPTION
Catch-up merge of `upstream/main` into `amd-staging` (8 commits), plus cleanup of stale commented-out workflow stubs that were causing the recurring merge-conflict failures.

## Why

The last two scheduled upstream-merge runs failed with a conflict in `.github/workflows/check-code-style.yml`. Root cause: that file (and two others) were left **fully commented-out** on `amd-staging` by `97f15430` ("Disable GH Actions for now", Oct 2024). Every time upstream edits one of those files, the merge re-conflicts against our commented-out copy.

## What changed

- **Merge commit** — merges `upstream/main`; the single conflict (`check-code-style.yml`) resolved by taking upstream's version verbatim.
- **Workflow re-sync commit** — takes upstream's versions of `patch-release.yaml` and `backport-to-branch.yml` (the other two stale commented-out stubs from the same 2024 commit).

After this, every workflow file shared with upstream is byte-identical to upstream, so this class of conflict is eliminated going forward.

`check-in-tree-build.yml` and `check-out-of-tree-build.yml` were already back in sync — untouched here.

## Post-merge follow-up

Two of the re-synced workflows will be disabled via the Actions UI / `gh workflow disable` once they exist un-commented on the default branch (`amd-staging`), since unlike `check-code-style` they would otherwise activate:
- `patch-release.yaml` — `schedule` + `workflow_dispatch`
- `backport-to-branch.yml` — `issue_comment` (`/backport`)

`check-code-style.yml` stays enabled — it's branch-filtered to `main`/`llvm_release_*` and never fires on `amd-staging` PRs.

> [!IMPORTANT]
> Merge with **"Create a merge commit"**, not squash — squashing destroys the upstream ancestry link and causes conflicts on every future merge.
