### PR TITLE
[CI] Use IMPORTANT alert for merge-commit note in upstream-merge PRs

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -108,11 +108,10 @@ jobs:
             --body "$(cat <<'EOF'
           Automated merge of upstream KhronosGroup/SPIRV-LLVM-Translator main branch.
 
-          **Merge this PR using "Create a merge commit" — do NOT squash.**
-          Squash-merging destroys upstream ancestry tracking and will cause
-          conflicts on every future merge.
-
           This PR was created automatically by the upstream-merge workflow.
+
+          > [!IMPORTANT]
+          > Merge with **"Create a merge commit"**, not squash — squashing destroys the upstream ancestry link and causes conflicts on every future merge.
           EOF
           )")
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Small formatting tweak to the automated upstream-merge PR body.

Replaces the plain bold "do NOT squash" note with a GitHub `> [!IMPORTANT]` alert so it renders as a highlighted callout in every automated upstream-merge PR, matching how we format it in manual merge PRs.

No behavioral change — only the `--body` text in the `Create Pull Request` step.
