### PR TITLE
Pin rocm-examples revision and add daily gated bump bot

### DIFF
--- a/.github/workflows/automerge-rocm-examples.yml
+++ b/.github/workflows/automerge-rocm-examples.yml
@@ -1,0 +1,120 @@
+# Merge-watcher for the rocm-examples pin bump PRs produced by
+# update-rocm-examples.yml (PR title "Bump rocm-examples pin").
+#
+# Unlike automerge-after-ci.yml, this does NOT require the whole "SPIRV
+# Compiler CI" workflow to succeed. The rocm-examples pin only depends on two
+# jobs -- Build and Test rocm-examples -- so an unrelated red job (test_codegen,
+# test_comgr, test_translator_lit) must not block the bump. We therefore fire on
+# any workflow_run conclusion and self-gate on the two specific check-runs.
+#
+# Because the jobs run inside the called reusable workflow spirv-ci-linux.yml
+# (via the "Linux::release" caller job), their check-run names surface as:
+#   "Linux::release / Build"
+#   "Linux::release / Test rocm-examples"
+# We suffix-match ("/ Build", "/ Test rocm-examples") to stay robust to caller
+# job renames.
+#
+# Requires (same App as upstream-merge.yml):
+#   - Secret MERGE_APP_ID
+#   - Secret MERGE_APP_PRIVATE_KEY
+#   - The MERGE_APP App must be a bypass actor on the
+#     block-merge-commit-on-amd-*-branches ruleset.
+
+name: Auto-merge rocm-examples pin PRs
+
+on:
+  workflow_run:
+    workflows: ["SPIRV Compiler CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: automerge-rocm-examples-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  gated-merge:
+    name: Merge rocm-examples bump if Build + Test rocm-examples passed
+    runs-on: ubuntu-latest
+    # Note: no conclusion == 'success' filter -- we self-gate on check-runs.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.display_title, 'Bump rocm-examples pin')
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
+      - name: Gate on Build + Test rocm-examples, then merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+        run: |
+          set -euo pipefail
+
+          # ---- Resolve the PR number -----------------------------------------
+          # Prefer workflow_run.pull_requests when GitHub attaches it
+          # (same-repo PRs). Fall back to a head-branch lookup.
+          PR=""
+          if command -v jq >/dev/null 2>&1; then
+            PR=$(echo "${PULL_REQUESTS_JSON}" | jq -r '
+              if . == null or . == [] then empty
+              elif type == "array" then .[0].number | tostring
+              else empty end' 2>/dev/null || true)
+          fi
+          if [ -z "${PR}" ] || [ "${PR}" = "null" ]; then
+            PR="$(gh pr list --repo "${REPO}" --head "${HEAD_BRANCH}" --base amd-staging --state open \
+              --json number -q '.[0].number // empty' 2>/dev/null || true)"
+          fi
+          if [ -z "${PR}" ] || [ "${PR}" = "null" ]; then
+            echo "No open PR found for head branch ${HEAD_BRANCH} -> amd-staging; skipping."
+            exit 0
+          fi
+
+          BASE="$(gh pr view "${PR}" --repo "${REPO}" --json baseRefName -q .baseRefName)"
+          if [ "${BASE}" != "amd-staging" ]; then
+            echo "PR #${PR} base is ${BASE}, not amd-staging; skipping."
+            exit 0
+          fi
+
+          DRAFT="$(gh pr view "${PR}" --repo "${REPO}" --json isDraft -q .isDraft)"
+          if [ "${DRAFT}" = "true" ]; then
+            echo "PR #${PR} is draft; skipping."
+            exit 0
+          fi
+
+          # ---- Self-gate on the two required check-runs ----------------------
+          RUNS=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate \
+            -q '.check_runs[] | [.name, .conclusion] | @tsv')
+          echo "Check-runs for ${HEAD_SHA}:"
+          printf '%s\n' "${RUNS}"
+
+          build_ok=$(printf '%s\n' "${RUNS}" \
+            | awk -F'\t' '$1 ~ /\/ Build$/ && $2 == "success"' | head -1)
+          examples_ok=$(printf '%s\n' "${RUNS}" \
+            | awk -F'\t' '$1 ~ /\/ Test rocm-examples$/ && $2 == "success"' | head -1)
+
+          if [ -z "${build_ok}" ] || [ -z "${examples_ok}" ]; then
+            echo "Gate not met (need both Build and Test rocm-examples = success); skipping."
+            echo "  Build ok:            ${build_ok:-<none>}"
+            echo "  Test rocm-examples:  ${examples_ok:-<none>}"
+            exit 0
+          fi
+
+          # ---- Merge ---------------------------------------------------------
+          # Direct merge as the bypass-eligible App: we have already confirmed
+          # our own gate, so we deliberately do not wait on org-level required
+          # checks (which may include unrelated jobs).
+          echo "Gate met for PR #${PR}; merging (merge commit)."
+          gh pr merge "${PR}" --repo "${REPO}" --merge

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -8,6 +8,12 @@ on:
   workflow_call:
 
 env:
+  # Pinned ROCm/rocm-examples revision consumed by the test_rocm_examples job.
+  # Bumped daily by .github/workflows/update-rocm-examples.yml, which lands the
+  # bump only after CI's Build + Test rocm-examples jobs pass on the candidate
+  # SHA (gated by .github/workflows/automerge-rocm-examples.yml). Keep this on
+  # its own line: the bumper rewrites exactly this line via sed.
+  ROCM_EXAMPLES_REF: 269e9068d6fd6e68b1cc5a76eb77744f88af42ec
   LLVM_BUILD: build
   DEVLIBS_BUILD: build-device-libs
   COMGR_BUILD: build-comgr
@@ -573,7 +579,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ROCm/rocm-examples
-          ref: amd-staging
+          ref: ${{ env.ROCM_EXAMPLES_REF }}
           path: rocm-examples
 
       - name: Download build tree artifact

--- a/.github/workflows/update-rocm-examples.yml
+++ b/.github/workflows/update-rocm-examples.yml
@@ -1,0 +1,195 @@
+# Daily bot that advances the pinned ROCm/rocm-examples revision consumed by
+# the test_rocm_examples job in spirv-ci-linux.yml (env ROCM_EXAMPLES_REF).
+#
+# Flow:
+#   1. Resolve the latest ROCm/rocm-examples amd-staging tip.
+#   2. If it already matches the pin -> nothing to do.
+#   3. Otherwise rewrite the ROCM_EXAMPLES_REF line, force-push a rolling
+#      branch (deps/rocm-examples), open/refresh a single PR, and enable
+#      auto-merge.
+#
+# The bump only LANDS if the candidate SHA passes CI's Build + Test
+# rocm-examples jobs -- that gate is enforced by automerge-rocm-examples.yml,
+# not here. This workflow just proposes the candidate.
+#
+# Rolling branch (force-pushed, single reused PR): a stale candidate that never
+# went green is simply replaced by the next day's tip -- no PR pile-up.
+#
+# Requires (same App as upstream-merge.yml):
+#   - Secret MERGE_APP_ID
+#   - Secret MERGE_APP_PRIVATE_KEY
+#   - Repository setting "Allow auto-merge" enabled.
+
+name: Update rocm-examples pin
+
+on:
+  schedule:
+    # Daily at 07:13 UTC. Off-the-hour to avoid cron-fleet pile-ups.
+    - cron: '13 7 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: update-rocm-examples
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # Push the rolling branch
+  pull-requests: write  # Create / update the PR
+
+env:
+  CI_FILE: .github/workflows/spirv-ci-linux.yml
+  ROLLING_BRANCH: deps/rocm-examples
+  BASE_BRANCH: amd-staging
+  EXAMPLES_REPO: ROCm/rocm-examples
+  EXAMPLES_BRANCH: amd-staging
+  PR_TITLE: Bump rocm-examples pin
+
+jobs:
+  update-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.MERGE_APP_ID }}
+          private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve latest rocm-examples tip
+        id: resolve
+        run: |
+          set -euo pipefail
+          LATEST=$(git ls-remote "https://github.com/${EXAMPLES_REPO}" \
+            "refs/heads/${EXAMPLES_BRANCH}" | cut -f1)
+          if [ -z "${LATEST}" ]; then
+            echo "::error::Could not resolve ${EXAMPLES_REPO}@${EXAMPLES_BRANCH}"
+            exit 1
+          fi
+          echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "Latest ${EXAMPLES_REPO}@${EXAMPLES_BRANCH}: ${LATEST}"
+
+      - name: Read current pin
+        id: current
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -oE 'ROCM_EXAMPLES_REF:[[:space:]]*[0-9a-fA-F]+' "${CI_FILE}" \
+            | awk '{print $2}')
+          if [ -z "${CURRENT}" ]; then
+            echo "::error::Could not find ROCM_EXAMPLES_REF in ${CI_FILE}"
+            exit 1
+          fi
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+          echo "Current pin: ${CURRENT}"
+
+      - name: Decide whether a bump is needed
+        id: decide
+        env:
+          LATEST: ${{ steps.resolve.outputs.latest }}
+          CURRENT: ${{ steps.current.outputs.current }}
+        run: |
+          set -euo pipefail
+          if [ "${LATEST}" = "${CURRENT}" ]; then
+            echo "Pin already at latest tip; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Bump needed: ${CURRENT} -> ${LATEST}"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rewrite pin line
+        if: steps.decide.outputs.changed == 'true'
+        env:
+          LATEST: ${{ steps.resolve.outputs.latest }}
+          CURRENT: ${{ steps.current.outputs.current }}
+        run: |
+          set -euo pipefail
+          sed -i "s/ROCM_EXAMPLES_REF:[[:space:]]*${CURRENT}/ROCM_EXAMPLES_REF: ${LATEST}/" "${CI_FILE}"
+          # Verify exactly the intended change happened.
+          if ! grep -q "ROCM_EXAMPLES_REF: ${LATEST}" "${CI_FILE}"; then
+            echo "::error::sed did not update the pin as expected"
+            git --no-pager diff -- "${CI_FILE}"
+            exit 1
+          fi
+          git --no-pager diff -- "${CI_FILE}"
+
+      - name: Push rolling branch
+        if: steps.decide.outputs.changed == 'true'
+        env:
+          LATEST: ${{ steps.resolve.outputs.latest }}
+        run: |
+          set -euo pipefail
+          SHORT="${LATEST:0:12}"
+          git checkout -B "${ROLLING_BRANCH}"
+          git add "${CI_FILE}"
+          git commit -m "Bump rocm-examples pin to ${SHORT}"
+          # Force-push: the rolling branch always carries a single bump commit
+          # on top of the current base tip.
+          git push --force origin "${ROLLING_BRANCH}"
+
+      - name: Create or refresh PR
+        id: pr
+        if: steps.decide.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          LATEST: ${{ steps.resolve.outputs.latest }}
+          CURRENT: ${{ steps.current.outputs.current }}
+        run: |
+          set -euo pipefail
+          PR=$(gh pr list --repo "${{ github.repository }}" \
+            --head "${ROLLING_BRANCH}" --base "${BASE_BRANCH}" --state open \
+            --json number -q '.[0].number // empty')
+
+          BODY=$(cat <<EOF
+          Automated bump of the pinned \`ROCm/rocm-examples\` revision consumed by
+          the \`test_rocm_examples\` job.
+
+          - From: \`${CURRENT}\`
+          - To:   \`${LATEST}\`
+
+          This PR is force-updated daily by the \`Update rocm-examples pin\`
+          workflow. It lands automatically only once the **Build** and
+          **Test rocm-examples** CI jobs pass on this commit (enforced by
+          \`automerge-rocm-examples.yml\`). Other CI jobs do not gate this bump.
+          EOF
+          )
+
+          if [ -z "${PR}" ]; then
+            gh pr create \
+              --repo "${{ github.repository }}" \
+              --base "${BASE_BRANCH}" \
+              --head "${ROLLING_BRANCH}" \
+              --title "${PR_TITLE}" \
+              --body "${BODY}"
+            PR=$(gh pr list --repo "${{ github.repository }}" \
+              --head "${ROLLING_BRANCH}" --base "${BASE_BRANCH}" --state open \
+              --json number -q '.[0].number // empty')
+          else
+            # Force-push already refreshed the branch; keep title/body current.
+            gh pr edit "${PR}" --repo "${{ github.repository }}" \
+              --title "${PR_TITLE}" --body "${BODY}"
+          fi
+          echo "number=${PR}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge (merge commit)
+        if: steps.decide.outputs.changed == 'true' && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Best-effort: the real gate is automerge-rocm-examples.yml, which
+          # merges once Build + Test rocm-examples are green. A force-push
+          # clears auto-merge, so re-assert it each run.
+          gh pr merge "${{ steps.pr.outputs.number }}" \
+            --repo "${{ github.repository }}" --auto --merge \
+            || echo "::warning::Could not enable auto-merge; watcher will merge on green gate."


### PR DESCRIPTION
## What

Pin the `ROCm/rocm-examples` revision consumed by the `test_rocm_examples` job
and add a bot that advances that pin daily, landing the bump only when CI's
**Build** and **Test rocm-examples** jobs pass.

## Why

`test_rocm_examples` in `spirv-ci-linux.yml` checked out `ROCm/rocm-examples` at
the floating `amd-staging` branch, so every CI run silently tested against a
different commit — breakages there were non-reproducible and unbisectable.

## Changes

- **`spirv-ci-linux.yml`** — new `env: ROCM_EXAMPLES_REF: <sha>` (single source
  of truth); checkout step now uses `ref: ${{ env.ROCM_EXAMPLES_REF }}` instead
  of `amd-staging`. Initial pin = current `rocm-examples/amd-staging` tip.
- **`update-rocm-examples.yml`** (new) — daily (`13 7 * * *`) + `workflow_dispatch`
  bot. Resolves the latest `rocm-examples/amd-staging` tip; if it differs from
  the pin, rewrites the one line, force-pushes a rolling branch
  `deps/rocm-examples`, opens/refreshes a single PR, and enables auto-merge.
- **`automerge-rocm-examples.yml`** (new) — `workflow_run` watcher on
  "SPIRV Compiler CI". Merges the bump PR **only** once the
  `Linux::release / Build` and `Linux::release / Test rocm-examples` check-runs
  are both `success`. Deliberately does not require whole-workflow success, so a
  red `test_codegen` / `test_comgr` / `test_translator_lit` never blocks the bump.

Reuses the existing `MERGE_APP_ID` / `MERGE_APP_PRIVATE_KEY` GitHub App (same as
`upstream-merge.yml`). No new secrets. No notifications.

## Notes / follow-ups

- Requires repo setting **Allow auto-merge** enabled and the App as a bypass
  actor on the merge-commit ruleset (already true for `upstream-merge.yml`).
- Draft: opening for review before enabling the schedule.