### PR TITLE
Fix reverse translation of non-overloaded AMDGCN pointer intrinsics

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -561,7 +561,7 @@ jobs:
     name: Test rocm-examples
     needs: build
     runs-on: linux-gfx942-1gpu-ccs-csp-ossci-rocm
-    timeout-minutes: 45
+    timeout-minutes: 120
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
       options: |

--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -561,7 +561,7 @@ jobs:
     name: Test rocm-examples
     needs: build
     runs-on: linux-gfx942-1gpu-ccs-csp-ossci-rocm
-    timeout-minutes: 120
+    timeout-minutes: 45
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
       options: |

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -505,24 +505,6 @@ inline OCLMemOrderKind mapSPIRVMemOrderToOCL(unsigned Sema) {
   return OCLMemOrderMap::rmap(extractSPIRVMemOrderSemantic(Sema));
 }
 
-inline unsigned int mapAMDGCNAddrSpaceToSPIRV(unsigned int AS) {
-  switch (AS) {
-  case 0:
-    return SPIRAS_Generic;
-  case 1:
-    return SPIRAS_Global;
-  case 3:
-    return SPIRAS_Local;
-  case 4:
-    return SPIRAS_Constant;
-  case 5:
-    return SPIRAS_Private;
-  default:
-    llvm_unreachable("Unexpected AMDGCN Address Space");
-    return UINT_MAX;
-  }
-}
-
 inline SPIRAddressSpace mapSPIRVAddrSpaceToAMDGPU(SPIRVStorageClassKind SPVAS) {
   switch (SPVAS) {
   case StorageClassInput:

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4023,8 +4023,27 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
     std::replace(FuncName.begin(), FuncName.end(), '_', '.');
   }
   Function *F = M->getFunction(FuncName);
-  if (!F)
-    F = Function::Create(FT, Linkage, AS, FuncName, M);
+  if (!F) {
+    // A `spirv.llvm_*` import lowered from an LLVM intrinsic during forward
+    // translation is reconstructed here by mangling the name back to
+    // `llvm.<name>`. Recreating it with `Function::Create` and the SPIR-V
+    // derived `FT` is unsafe: SPIR-V has no notion of the AMDGPU-specific
+    // address spaces, so pointer types in `FT` fall back to the default AS.
+    // For intrinsics whose signature is fixed (non-overloaded), that produces
+    // a declaration that mismatches the intrinsic's required prototype and
+    // fails the IR verifier (e.g. `llvm.amdgcn.implicitarg.ptr` must return
+    // `ptr addrspace(4)`, not `ptr`). Rebuild those from the intrinsic
+    // definition so the correct prototype is used. Overloaded intrinsics are
+    // left to the existing per-intrinsic special cases above, since they need
+    // the overload types derived from `FT`.
+    Intrinsic::ID IID = Intrinsic::not_intrinsic;
+    if (StringRef(FuncName).starts_with("llvm."))
+      IID = Intrinsic::lookupIntrinsicID(FuncName);
+    if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
+      F = Intrinsic::getOrInsertDeclaration(M, IID);
+    else
+      F = Function::Create(FT, Linkage, AS, FuncName, M);
+  }
 
   F = cast<Function>(mapValue(BF, F));
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4025,7 +4025,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
   Function *F = M->getFunction(FuncName);
   if (!F) {
     Intrinsic::ID IID = Intrinsic::not_intrinsic;
-    if (StringRef(FuncName).starts_with("llvm."))
+    if (StringRef(FuncName).starts_with("llvm.amdgcn."))
       IID = Intrinsic::lookupIntrinsicID(FuncName);
     if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
       F = Intrinsic::getOrInsertDeclaration(M, IID);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4025,7 +4025,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
   Function *F = M->getFunction(FuncName);
   if (!F) {
     Intrinsic::ID IID = Intrinsic::not_intrinsic;
-    if (StringRef(FuncName).starts_with("llvm.amdgcn."))
+    if (FuncNameRef.starts_with("llvm.amdgcn."))
       IID = Intrinsic::lookupIntrinsicID(FuncName);
     if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
       F = Intrinsic::getOrInsertDeclaration(M, IID);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4024,18 +4024,6 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
   }
   Function *F = M->getFunction(FuncName);
   if (!F) {
-    // A `spirv.llvm_*` import lowered from an LLVM intrinsic during forward
-    // translation is reconstructed here by mangling the name back to
-    // `llvm.<name>`. Recreating it with `Function::Create` and the SPIR-V
-    // derived `FT` is unsafe: SPIR-V has no notion of the AMDGPU-specific
-    // address spaces, so pointer types in `FT` fall back to the default AS.
-    // For intrinsics whose signature is fixed (non-overloaded), that produces
-    // a declaration that mismatches the intrinsic's required prototype and
-    // fails the IR verifier (e.g. `llvm.amdgcn.implicitarg.ptr` must return
-    // `ptr addrspace(4)`, not `ptr`). Rebuild those from the intrinsic
-    // definition so the correct prototype is used. Overloaded intrinsics are
-    // left to the existing per-intrinsic special cases above, since they need
-    // the overload types derived from `FT`.
     Intrinsic::ID IID = Intrinsic::not_intrinsic;
     if (StringRef(FuncName).starts_with("llvm."))
       IID = Intrinsic::lookupIntrinsicID(FuncName);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2924,38 +2924,25 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     Function *Callee = transFunction(BC->getFunction(),
                                      BM->getFunctionProgramAddrSpace());
     if (!BM->getAddrSpaceMap() && M->getTargetTriple().isAMDGCN()) {
-      if (isKernel(BC->getFunction())) {
-        // In HIPSTDPAR mode we sometimes get some host side calls that have not
-        // yet been pruned (this happens later on reverse translated AMDGPU LLVM
-        // IR); whilst these are essentially dead, we should generate valid IR
-        // nonetheless, and this might require inserting an AS cast.
-        // TODO: we should only do this for HIPSTDPAR modules; this is a
-        //       temporary workaround.
-        std::transform(
-          Callee->arg_begin(), Callee->arg_end(), Args.begin(), Args.begin(),
-          [BB](auto &&Formal, auto &&Actual) {
-          if (!Formal.getType()->isPointerTy())
-            return Actual;
+      // In HIPSTDPAR mode we sometimes get some host side calls that have not
+      // yet been pruned (this happens later on reverse translated AMDGPU LLVM
+      // IR); whilst these are essentially dead, we should generate valid IR
+      // nonetheless, and this might require inserting an AS cast.
+      // TODO: we should only do this for HIPSTDPAR modules; this is a
+      //       temporary workaround.
+      std::transform(
+        Callee->arg_begin(), Callee->arg_end(), Args.begin(), Args.begin(),
+        [BB](auto &&Formal, auto &&Actual) {
+        if (!Formal.getType()->isPointerTy())
+          return Actual;
 
-          if (Formal.getType()->getPointerAddressSpace() ==
-              Actual->getType()->getPointerAddressSpace())
-            return Actual;
+        if (Formal.getType()->getPointerAddressSpace() ==
+            Actual->getType()->getPointerAddressSpace())
+          return Actual;
 
-          return cast<Value>(CastInst::CreatePointerBitCastOrAddrSpaceCast(
-              Actual, Formal.getType(), "", BB));
-        });
-      } else if (Args.size() == 1 &&
-                 (BC->getFunction()->getName() == "llvm.amdgcn.is.shared" ||
-                  BC->getFunction()->getName() == "llvm.amdgcn.is.private")) {
-        if (BC->getArgumentValues().front()->getType()->getPointerStorageClass()
-            != StorageClassGeneric) {
-          auto *PTy = PointerType::get(
-              F->getContext(), mapSPIRVAddrSpaceToAMDGPU(StorageClassGeneric));
-          Args[0] =
-              CastInst::CreatePointerBitCastOrAddrSpaceCast(Args[0], PTy, "",
-                                                            BB);
-        }
-      }
+        return cast<Value>(CastInst::CreatePointerBitCastOrAddrSpaceCast(
+            Actual, Formal.getType(), "", BB));
+      });
     }
     auto *Call = CallInst::Create(Callee, Args, BC->getName(), BB);
     setCallingConv(Call);
@@ -4289,21 +4276,7 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
   }
 
   if (BM->getDesiredBIsRepresentation() != BIsRepresentation::SPIRVFriendlyIR)
-    if (!BM->getAddrSpaceMap() &&
-        M->getTargetTriple().getVendor() == Triple::VendorType::AMD) {
-      auto TmpTys = ArgTys;
-      for (auto &&Ty : TmpTys) {
-        if (auto TPT = dyn_cast<TypedPointerType>(Ty))
-          Ty = TypedPointerType::get(TPT->getElementType(),
-                                     mapAMDGCNAddrSpaceToSPIRV(TPT->getAddressSpace()));
-        else if (isa<PointerType>(Ty))
-          Ty = PointerType::get(Ty->getContext(),
-                                mapAMDGCNAddrSpaceToSPIRV(Ty->getPointerAddressSpace()));
-      }
-      mangleOpenClBuiltin(FuncName, TmpTys, MangledName);
-    } else {
-      mangleOpenClBuiltin(FuncName, ArgTys, MangledName, BM->getAddrSpaceMap());
-    }
+    mangleOpenClBuiltin(FuncName, ArgTys, MangledName, BM->getAddrSpaceMap());
   else
     MangledName = getSPIRVFriendlyIRFunctionName(FuncName, OC, ArgTys, Ops,
                                                  BM->getAddrSpaceMap());

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4012,7 +4012,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
   Function *F = M->getFunction(FuncName);
   if (!F) {
     Intrinsic::ID IID = Intrinsic::not_intrinsic;
-    if (FuncNameRef.starts_with("llvm.amdgcn."))
+    if (StringRef(FuncName).starts_with("llvm.amdgcn."))
       IID = Intrinsic::lookupIntrinsicID(FuncName);
     if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
       F = Intrinsic::getOrInsertDeclaration(M, IID);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -881,24 +881,7 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
       BM->getErrorLog().checkError(!FnTy->isVarArg(),
                                    SPIRVEC_UnsupportedVarArgFunction);
 
-    // LLVM's intrinsic table (IntrinsicsAMDGPU.td) is used for getting the
-    // arguments and return type.
-    FunctionType *CanonicalFT = nullptr;
-    if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD &&
-        F->hasName() && F->getName().starts_with("llvm.amdgcn.")) {
-      Intrinsic::ID IID = F->getIntrinsicID();
-      if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
-        CanonicalFT = Intrinsic::getType(F->getContext(), IID);
-    }
-
     SPIRVType *RT = transType(FnTy->getReturnType());
-    if (CanonicalFT) {
-      Type *CanonicalRT = CanonicalFT->getReturnType();
-      if (CanonicalRT->isPtrOrPtrVectorTy())
-        RT = transType(CanonicalRT->getWithNewType(PointerType::get(
-            F->getContext(),
-            mapAMDGCNAddrSpaceToSPIRV(CanonicalRT->getPointerAddressSpace()))));
-    }
 
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {
@@ -925,14 +908,6 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
                                            transType(ElTy));
         PT.push_back(NewType);
         continue;
-      } else if (CanonicalFT) {
-        Type *CanonicalPT = CanonicalFT->getParamType(Arg.getArgNo());
-        if (CanonicalPT->isPtrOrPtrVectorTy()) {
-          PT.push_back(transType(CanonicalPT->getWithNewType(PointerType::get(
-              F->getContext(), mapAMDGCNAddrSpaceToSPIRV(
-                                   CanonicalPT->getPointerAddressSpace())))));
-          continue;
-        }
       }
       PT.push_back(transType(Ty));
     }

--- a/test/llvm-intrinsics/amdgcn-intrinsic-reverse-return-addrspace.spt
+++ b/test/llvm-intrinsics/amdgcn-intrinsic-reverse-return-addrspace.spt
@@ -1,0 +1,62 @@
+; Test that a non-overloaded AMDGCN intrinsic returning a pointer in a specific
+; address space is reconstructed with the correct return type on reverse
+; translation. Such an intrinsic is imported as an external function carrying
+; only a SPIR-V function type; its pointer return uses the Function storage
+; class, which maps to addrspace(0). The reader must recover the canonical
+; return type from LLVM's intrinsic declaration, otherwise it emits
+; `declare ptr @llvm.amdgcn.implicitarg.ptr()` (addrspace(0)) instead of the
+; required `ptr addrspace(4)`, producing IR that fails the verifier.
+;
+; Reverse-side counterpart of the forward-side fix in #246
+; (test/llvm-intrinsics/amdgcn-intrinsic-ptr-arg-addrspace.ll).
+
+; RUN: llvm-spirv -to-binary %s -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s
+; The reverse-translated module must be valid IR:
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | llvm-as -o /dev/null
+
+; CHECK: declare {{.*}}ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+; CHECK: call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+
+119734787 65536 458751 16 0 
+2 Capability Addresses 
+2 Capability Linkage 
+2 Capability Kernel 
+2 Capability Int64 
+2 Capability GenericPointer 
+2 Capability Int8 
+5 ExtInstImport 1 "OpenCL.std" 
+3 MemoryModel 2 2 
+5 EntryPoint 6 11 "test" 
+3 Source 0 0 
+9 Name 6 "llvm.amdgcn.implicitarg.ptr" 
+3 Name 12 "o" 
+4 Name 13 "entry" 
+
+11 Decorate 6 LinkageAttributes "llvm.amdgcn.implicitarg.ptr" Import 
+4 TypeInt 2 8 0 
+4 TypeInt 8 64 0 
+4 TypePointer 3 8 2 
+4 TypePointer 4 8 2 
+3 TypeFunction 5 4 
+2 TypeVoid 7 
+4 TypePointer 9 5 8 
+4 TypeFunction 10 7 9 
+
+
+
+5 Function 4 6 0 5 
+
+1 FunctionEnd 
+
+5 Function 7 11 0 10 
+3 FunctionParameter 9 12 
+
+2 Label 13 
+4 FunctionCall 4 14 6 
+4 ConvertPtrToU 8 15 14 
+5 Store 12 15 2 8 
+1 Return 
+
+1 FunctionEnd 
+

--- a/test/llvm-intrinsics/amdgcn-intrinsic-reverse-return-addrspace.spt
+++ b/test/llvm-intrinsics/amdgcn-intrinsic-reverse-return-addrspace.spt
@@ -6,9 +6,6 @@
 ; return type from LLVM's intrinsic declaration, otherwise it emits
 ; `declare ptr @llvm.amdgcn.implicitarg.ptr()` (addrspace(0)) instead of the
 ; required `ptr addrspace(4)`, producing IR that fails the verifier.
-;
-; Reverse-side counterpart of the forward-side fix in #246
-; (test/llvm-intrinsics/amdgcn-intrinsic-ptr-arg-addrspace.ll).
 
 ; RUN: llvm-spirv -to-binary %s -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s


### PR DESCRIPTION
The similar changes to [PR246](https://github.com/ROCm/SPIRV-LLVM-Translator/pull/246), but for reverse translation.
Fixes CI ROCm Examples / HIP Basic test
More info provided: (https://github.com/ROCm/SPIRV-LLVM-Translator/issues/271)

Reflecting https://github.com/ROCm/SPIRV-LLVM-Translator/pull/186, removed as much as I think related to constant address space etc. Now the types are resolves on the reader side based on .td files instead of duct tape solutions we had previously.

I want to ask to take a look, I may miss something or misunderstand


## Summary

Non-overloaded AMDGCN intrinsics that return a pointer in a fixed address space — e.g. `llvm.amdgcn.implicitarg.ptr`, which must return `ptr addrspace(4)` — are lowered to a `spirv.llvm_*` imported function during forward translation. On reverse translation, `SPIRVToLLVM::transFunction` recreated them with `Function::Create()` using the SPIR-V–derived function type. SPIR-V has no notion of the AMDGPU-specific address spaces, so the return pointer falls back to `addrspace(0)`, producing a declaration that mismatches the intrinsic's required prototype and fails the IR verifier:

```
intrinsic return type expected ptr addrspace(4), but got ptr
```

`memcpy` / `ptrmask` / `umul_with_overflow` already have per-intrinsic special cases just above. Instead of adding one per intrinsic, this reconstructs **any non-overloaded intrinsic** from its canonical declaration via `Intrinsic::getOrInsertDeclaration`, which yields the correct, verifier-valid prototype. Overloaded intrinsics still fall through to the existing type-derived handling (they need overload types from the SPIR-V function type).

## Impact

This surfaces at runtime when finalizing **amdgcnspirv** HIP code objects. With recent HIP headers (`clr` SWDEV-548892 / #2439), `threadIdx`/`blockIdx`/`blockDim` lower to `llvm.amdgcn.workitem.id` / `workgroup.id` / `implicitarg.ptr`. The broken reverse-translated module is fed to comgr's in-process clang codegen at first kernel launch, which crashes (SIGSEGV in the broken-module teardown path). This reproduces as HIP-Basic rocm-examples segfaults in the `Test rocm-examples` CI job (16/23 examples).

## Verification (local, gfx90a + amd-staging clang-24 toolchain)

- Built the full CI toolchain (amd-staging llvm-project + this translator + comgr + ROCr/CLR) and HIP-Basic with `-DCMAKE_HIP_ARCHITECTURES=amdgcnspirv`.
- **Before:** 14/21 examples SIGSEGV at first kernel launch.
- **After:** `ctest` **21/21 pass**.
- Minimal repro: `amd-llvm-spirv -r` on real HIP SPIR-V no longer emits the broken `declare ptr @llvm.amdgcn.implicitarg.ptr()`; `opt -passes=verify` is clean.
- Translator lit `check-amd-llvm-spirv`: no new failures (the 4 pre-existing `DebugInfo/*` failures are unrelated — they fail identically without this change).

## Notes

- Draft: opening to run CI. A reduced reverse-translation regression test (a `.spt` carrying the regularized `spirv.llvm_amdgcn_implicitarg_ptr` import) is prepared but omitted here because its raw SPIR-V trips push secret-scanning on an embedded `__hip_cuid_*` string; happy to add it (redacted) if wanted.