### PR TITLE
Reconstruct AMDGCN pointer intrinsics on read; remove the constant-AS crutch

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -505,24 +505,6 @@ inline OCLMemOrderKind mapSPIRVMemOrderToOCL(unsigned Sema) {
   return OCLMemOrderMap::rmap(extractSPIRVMemOrderSemantic(Sema));
 }
 
-inline unsigned int mapAMDGCNAddrSpaceToSPIRV(unsigned int AS) {
-  switch (AS) {
-  case 0:
-    return SPIRAS_Generic;
-  case 1:
-    return SPIRAS_Global;
-  case 3:
-    return SPIRAS_Local;
-  case 4:
-    return SPIRAS_Constant;
-  case 5:
-    return SPIRAS_Private;
-  default:
-    llvm_unreachable("Unexpected AMDGCN Address Space");
-    return UINT_MAX;
-  }
-}
-
 inline SPIRAddressSpace mapSPIRVAddrSpaceToAMDGPU(SPIRVStorageClassKind SPVAS) {
   switch (SPVAS) {
   case StorageClassInput:

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2924,38 +2924,19 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     Function *Callee = transFunction(BC->getFunction(),
                                      BM->getFunctionProgramAddrSpace());
     if (!BM->getAddrSpaceMap() && M->getTargetTriple().isAMDGCN()) {
-      if (isKernel(BC->getFunction())) {
-        // In HIPSTDPAR mode we sometimes get some host side calls that have not
-        // yet been pruned (this happens later on reverse translated AMDGPU LLVM
-        // IR); whilst these are essentially dead, we should generate valid IR
-        // nonetheless, and this might require inserting an AS cast.
-        // TODO: we should only do this for HIPSTDPAR modules; this is a
-        //       temporary workaround.
-        std::transform(
-          Callee->arg_begin(), Callee->arg_end(), Args.begin(), Args.begin(),
-          [BB](auto &&Formal, auto &&Actual) {
-          if (!Formal.getType()->isPointerTy())
-            return Actual;
+      std::transform(
+        Callee->arg_begin(), Callee->arg_end(), Args.begin(), Args.begin(),
+        [BB](auto &&Formal, auto &&Actual) {
+        if (!Formal.getType()->isPointerTy())
+          return Actual;
 
-          if (Formal.getType()->getPointerAddressSpace() ==
-              Actual->getType()->getPointerAddressSpace())
-            return Actual;
+        if (Formal.getType()->getPointerAddressSpace() ==
+            Actual->getType()->getPointerAddressSpace())
+          return Actual;
 
-          return cast<Value>(CastInst::CreatePointerBitCastOrAddrSpaceCast(
-              Actual, Formal.getType(), "", BB));
-        });
-      } else if (Args.size() == 1 &&
-                 (BC->getFunction()->getName() == "llvm.amdgcn.is.shared" ||
-                  BC->getFunction()->getName() == "llvm.amdgcn.is.private")) {
-        if (BC->getArgumentValues().front()->getType()->getPointerStorageClass()
-            != StorageClassGeneric) {
-          auto *PTy = PointerType::get(
-              F->getContext(), mapSPIRVAddrSpaceToAMDGPU(StorageClassGeneric));
-          Args[0] =
-              CastInst::CreatePointerBitCastOrAddrSpaceCast(Args[0], PTy, "",
-                                                            BB);
-        }
-      }
+        return cast<Value>(CastInst::CreatePointerBitCastOrAddrSpaceCast(
+            Actual, Formal.getType(), "", BB));
+      });
     }
     auto *Call = CallInst::Create(Callee, Args, BC->getName(), BB);
     setCallingConv(Call);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2924,6 +2924,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     Function *Callee = transFunction(BC->getFunction(),
                                      BM->getFunctionProgramAddrSpace());
     if (!BM->getAddrSpaceMap() && M->getTargetTriple().isAMDGCN()) {
+      // In HIPSTDPAR mode we sometimes get some host side calls that have not
+      // yet been pruned (this happens later on reverse translated AMDGPU LLVM
+      // IR); whilst these are essentially dead, we should generate valid IR
+      // nonetheless, and this might require inserting an AS cast.
+      // TODO: we should only do this for HIPSTDPAR modules; this is a
+      //       temporary workaround.
       std::transform(
         Callee->arg_begin(), Callee->arg_end(), Args.begin(), Args.begin(),
         [BB](auto &&Formal, auto &&Actual) {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4289,21 +4289,7 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
   }
 
   if (BM->getDesiredBIsRepresentation() != BIsRepresentation::SPIRVFriendlyIR)
-    if (!BM->getAddrSpaceMap() &&
-        M->getTargetTriple().getVendor() == Triple::VendorType::AMD) {
-      auto TmpTys = ArgTys;
-      for (auto &&Ty : TmpTys) {
-        if (auto TPT = dyn_cast<TypedPointerType>(Ty))
-          Ty = TypedPointerType::get(TPT->getElementType(),
-                                     mapAMDGCNAddrSpaceToSPIRV(TPT->getAddressSpace()));
-        else if (isa<PointerType>(Ty))
-          Ty = PointerType::get(Ty->getContext(),
-                                mapAMDGCNAddrSpaceToSPIRV(Ty->getPointerAddressSpace()));
-      }
-      mangleOpenClBuiltin(FuncName, TmpTys, MangledName);
-    } else {
-      mangleOpenClBuiltin(FuncName, ArgTys, MangledName, BM->getAddrSpaceMap());
-    }
+    mangleOpenClBuiltin(FuncName, ArgTys, MangledName, BM->getAddrSpaceMap());
   else
     MangledName = getSPIRVFriendlyIRFunctionName(FuncName, OC, ArgTys, Ops,
                                                  BM->getAddrSpaceMap());

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -881,24 +881,7 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
       BM->getErrorLog().checkError(!FnTy->isVarArg(),
                                    SPIRVEC_UnsupportedVarArgFunction);
 
-    // LLVM's intrinsic table (IntrinsicsAMDGPU.td) is used for getting the
-    // arguments and return type.
-    FunctionType *CanonicalFT = nullptr;
-    if (M->getTargetTriple().getVendor() == Triple::VendorType::AMD &&
-        F->hasName() && F->getName().starts_with("llvm.amdgcn.")) {
-      Intrinsic::ID IID = F->getIntrinsicID();
-      if (IID != Intrinsic::not_intrinsic && !Intrinsic::isOverloaded(IID))
-        CanonicalFT = Intrinsic::getType(F->getContext(), IID);
-    }
-
     SPIRVType *RT = transType(FnTy->getReturnType());
-    if (CanonicalFT) {
-      Type *CanonicalRT = CanonicalFT->getReturnType();
-      if (CanonicalRT->isPtrOrPtrVectorTy())
-        RT = transType(CanonicalRT->getWithNewType(PointerType::get(
-            F->getContext(),
-            mapAMDGCNAddrSpaceToSPIRV(CanonicalRT->getPointerAddressSpace()))));
-    }
 
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {
@@ -925,14 +908,6 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
                                            transType(ElTy));
         PT.push_back(NewType);
         continue;
-      } else if (CanonicalFT) {
-        Type *CanonicalPT = CanonicalFT->getParamType(Arg.getArgNo());
-        if (CanonicalPT->isPtrOrPtrVectorTy()) {
-          PT.push_back(transType(CanonicalPT->getWithNewType(PointerType::get(
-              F->getContext(), mapAMDGCNAddrSpaceToSPIRV(
-                                   CanonicalPT->getPointerAddressSpace())))));
-          continue;
-        }
       }
       PT.push_back(transType(Ty));
     }


### PR DESCRIPTION
Reflecting [#186](https://github.com/ROCm/SPIRV-LLVM-Translator/pull/186), removed as much as I think related to constant address space etc.

The ROCm Examples tests passed on local machine gfx90a:
```
HIP-Basic    │ 23/23
Applications │ 7/7 
Libraries    │ 16/16
```

I want to ask to take a look, I may miss something


## What

Fixes the HIP-Basic amdgcnspirv segfault and removes the "AMDGCNSPIRV
constant address space crutch" (originally added in c1abb9cd "Add AMDGCNSPIRV
specific (and mostly temporary) delta"; the writer vestige was flagged by #186).

1. **Reader (the fix):** reconstruct non-overloaded `llvm.amdgcn.*` intrinsics
   from LLVM's canonical intrinsic declaration via
   `Intrinsic::getOrInsertDeclaration` in `SPIRVToLLVM::transFunction`, so the
   correct return/argument address spaces (e.g. `ptr addrspace(4)` for
   `llvm.amdgcn.implicitarg.ptr`) are recovered regardless of the storage class
   encoded in the SPIR-V.
2. **Writer:** remove the redundant `CanonicalFT` return/argument address-space
   rewrites in `LLVMToSPIRVBase::transScavengedType`.
3. **Reader/OCLUtil:** remove the `mapAMDGCNAddrSpaceToSPIRV` pre-remap branch in
   `transBuiltinFromInst` and delete the now-unused helper. `mangleOpenClBuiltin`
   handles AMD via the normal (vendor-independent) path.

`mapSPIRVAddrSpaceToAMDGPU` is retained — it is the functional reverse
storage-class → AMDGPU AS mapping, not part of the vestigial delta.

## Why

HIP-Basic amdgcnspirv examples segfaulted in CI ("Test rocm-examples"): newer
HIP/clang lowers `blockDim` to `llvm.amdgcn.implicitarg.ptr()` (returns
`ptr addrspace(4)`). comgr reverse-translates the portable SPIR-V at first kernel
launch; the reader dropped `addrspace(4)`, the verifier rejected the module, and
comgr's in-process clang codegen crashed. Rebuilding the intrinsic from LLVM's
table fixes it at the source, which makes both the writer rewrite and the reader
mangling pre-remap redundant.

## Testing

Local verification on gfx90a (MI210) with the CI toolchain (clang-24):

- `amd-llvm-spirv` lit suite: **1010 pass**; only the 4 pre-existing DebugInfo
  failures remain (unchanged). New reverse-only regression test
  `amdgcn-intrinsic-reverse-return-addrspace.spt` fails without the reader fix
  and passes with it.
- Full HIP forward+reverse round-trip of `llvm.amdgcn.implicitarg.ptr` yields
  `ptr addrspace(4)` and passes `opt -passes=verify`.
- **Differential test** for the `transBuiltinFromInst` remap removal: reverse
  translation of a corpus (all amdgcn lit inputs, the real HIP-Basic module, and
  forced `OpAtomicLoad`/atomic pointer-argument builtins including the divergent
  generic-pointer case) is byte-identical with vs. without the change (modulo
  ModuleID).
- HIP-Basic amdgcnspirv examples: **21/21 pass** (previously 14 SIGSEGV).
