### PR TITLE
[SPIRV] CI: drop secrets: inherit from spirv-ci dispatcher

### DIFF
--- a/.github/workflows/spirv-ci.yml
+++ b/.github/workflows/spirv-ci.yml
@@ -22,9 +22,7 @@ jobs:
   linux_release:
     name: Linux::release
     uses: ./.github/workflows/spirv-ci-linux.yml
-    secrets: inherit
 
   windows_release:
     name: Windows::release
     uses: ./.github/workflows/spirv-ci-windows.yml
-    secrets: inherit


### PR DESCRIPTION
## Summary

The `spirv-ci` dispatcher passed the full set of repository secrets to its reusable linux/windows workflows via `secrets: inherit`, but neither reusable workflow references any repository secret. This removes the passthrough so no secrets are propagated to the callees (least privilege).

## Why this is safe

- `spirv-ci-linux.yml` and `spirv-ci-windows.yml` contain zero secret references (`${{ secrets.* }}`).
- `GITHUB_TOKEN` is provided to reusable workflows automatically and is **not** governed by `secrets: inherit`. The caller `permissions:` block (`contents: read`, `pull-requests: write`) continues to scope it for the translator-lit sticky-comment job.
- No behavior change to the CI.

## Change

Remove `secrets: inherit` from both the `linux_release` and `windows_release` call sites in `.github/workflows/spirv-ci.yml`.
