### PR TITLE
Upstream merge 2026-08-12 (manual conflict resolution)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4718,9 +4718,9 @@ void SPIRVToLLVM::transGlobalAnnotations() {
   }
 }
 
-static llvm::MDNode *
-transDecorationsToMetadataList(llvm::LLVMContext *Context,
-                               std::vector<SPIRVDecorate const *> Decorates) {
+static llvm::MDNode *transDecorationsToMetadataList(
+    llvm::LLVMContext *Context,
+    std::vector<SPIRVDecorateGeneric const *> Decorates) {
   SmallVector<Metadata *, 4> MDs;
   MDs.reserve(Decorates.size());
   for (const auto *Deco : Decorates) {
@@ -4768,6 +4768,15 @@ transDecorationsToMetadataList(llvm::LLVMContext *Context,
       OPs.push_back(StrMD);
       break;
     }
+    case DecorationUniformId: {
+      SPIRVId ScopeId = Deco->getVecLiteral()[0];
+      auto *ScopeConst =
+          static_cast<SPIRVConstant *>(Deco->getModule()->getValue(ScopeId));
+      auto *const ScopeMD = ConstantAsMetadata::get(ConstantInt::get(
+          Type::getInt32Ty(*Context), ScopeConst->getZExtIntValue()));
+      OPs.push_back(ScopeMD);
+      break;
+    }
     default: {
       for (const SPIRVWord Lit : Deco->getVecLiteral()) {
         auto *const LitMD = ConstantAsMetadata::get(
@@ -4787,7 +4796,8 @@ void SPIRVToLLVM::transDecorationsToMetadata(SPIRVValue *BV, Value *V) {
     return;
 
   auto SetDecorationsMetadata = [&](auto V) {
-    std::vector<SPIRVDecorate const *> Decorates = BV->getDecorations();
+    std::vector<SPIRVDecorateGeneric const *> Decorates =
+        BV->getAllDecorations();
     if (!Decorates.empty()) {
       MDNode *MDList = transDecorationsToMetadataList(Context, Decorates);
       V->setMetadata(SPIRV_MD_DECORATIONS, MDList);
@@ -4998,7 +5008,7 @@ void SPIRVToLLVM::transFunctionDecorationsToMetadata(SPIRVFunction *BF,
   addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,
                             [this](SPIRVFunctionParameter *Arg) {
                               return transDecorationsToMetadataList(
-                                  Context, Arg->getDecorations());
+                                  Context, Arg->getAllDecorations());
                             });
 }
 
@@ -5328,7 +5338,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
   addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,
                             [this](SPIRVFunctionParameter *Arg) {
                               return transDecorationsToMetadataList(
-                                  Context, Arg->getDecorations());
+                                  Context, Arg->getAllDecorations());
                             });
   return true;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1640,13 +1640,19 @@ SPIRVInstruction *LLVMToSPIRVBase::transBinaryInst(BinaryOperator *B,
 SPIRVInstruction *LLVMToSPIRVBase::transCmpInst(CmpInst *Cmp,
                                                 SPIRVBasicBlock *BB) {
   auto *Op0 = Cmp->getOperand(0);
-  SPIRVValue *TOp0 = transValue(Op0, BB);
-  SPIRVValue *TOp1 = transValue(Cmp->getOperand(1), BB);
+  auto *Op1 = Cmp->getOperand(1);
+  SPIRVValue *TOp0 = transValue(Op0, BB, true, FuncTransMode::Pointer);
+  SPIRVValue *TOp1 = transValue(Op1, BB, true, FuncTransMode::Pointer);
   if (Op0->getType()->isPointerTy()) {
     auto P = Cmp->getPredicate();
     if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4) &&
         (P == ICmpInst::ICMP_EQ || P == ICmpInst::ICMP_NE) &&
         Cmp->getOperand(1)->getType()->isPointerTy()) {
+      // OpPtrEqual/OpPtrNotEqual require both operands to be of the same
+      // pointer type. Bitcast the second operand to the first operand's
+      // type if they differ.
+      if (TOp1->getType() != TOp0->getType())
+        TOp1 = BM->addUnaryInst(OpBitcast, TOp0->getType(), TOp1, BB);
       Op OC = P == ICmpInst::ICMP_EQ ? OpPtrEqual : OpPtrNotEqual;
       return BM->addBinaryInst(OC, transType(Cmp->getType()), TOp0, TOp1, BB);
     }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3065,6 +3065,19 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       Target->addDecorate(new SPIRVDecorate(DecoKind, Target));
       break;
     }
+    case DecorationUniformId: {
+      ErrLog.checkError(NumOperands == 2, SPIRVEC_InvalidLlvmModule,
+                        "UniformId requires exactly 1 extra operand");
+      auto *ScopeEO = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
+      ErrLog.checkError(ScopeEO, SPIRVEC_InvalidLlvmModule,
+                        "UniformId requires extra operand to be an integer");
+      SPIRVModule *BM = Target->getModule();
+      SPIRVValue *ScopeConst = BM->addIntegerConstant(BM->addIntegerType(32),
+                                                      ScopeEO->getZExtValue());
+      Target->addDecorate(
+          new SPIRVDecorateId(DecoKind, Target, ScopeConst->getId()));
+      break;
+    }
     case DecorationBufferLocationINTEL:
     case DecorationMMHostInterfaceReadWriteModeINTEL:
     case DecorationMMHostInterfaceAddressWidthINTEL:

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2603,6 +2603,12 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                LoopControl, Parameters, SuccessorTrue);
       }
     }
+    // Starting with SPIR-V 1.6, the True Label and False Label of an
+    // "OpBranchConditional" must not be the same, so emit an unconditional
+    // branch - always valid, required for 1.6+
+    if (SuccessorTrue == SuccessorFalse)
+      return mapValue(V, BM->addBranchInst(SuccessorTrue, BB));
+
     return mapValue(
         V, BM->addBranchConditionalInst(transValue(Branch->getCondition(), BB),
                                         SuccessorTrue, SuccessorFalse, BB));
@@ -2657,8 +2663,16 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                    FuncTransMode::Pointer);
       if (Val->getType() != Ty)
         Val = BM->addUnaryInst(OpBitcast, Ty, Val, BB);
-      IncomingPairs.push_back(Val);
-      IncomingPairs.push_back(transValue(Phi->getIncomingBlock(I), nullptr));
+      SPIRVValue *Block = transValue(Phi->getIncomingBlock(I), nullptr);
+      bool IsDuplicate = false;
+      for (size_t Idx = 1; Idx < IncomingPairs.size(); Idx += 2) {
+        if (IncomingPairs[Idx] == Block)
+          IsDuplicate = true;
+      }
+      if (!IsDuplicate) {
+        IncomingPairs.push_back(Val);
+        IncomingPairs.push_back(Block);
+      }
     }
     return mapValue(V, BM->addPhiInst(Ty, IncomingPairs, BB));
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1063,8 +1063,8 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
 
   if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_maximum_registers))
     transFunctionMetadataAsExecutionMode(BF, F);
-  else
-    transFunctionMetadataAsUserSemanticDecoration(BF, F);
+
+  transFunctionMetadataAsUserSemanticDecoration(BF, F);
 
   transAuxDataInst(BF, F);
 
@@ -1207,32 +1207,32 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
 
 void LLVMToSPIRVBase::transFunctionMetadataAsExecutionMode(SPIRVFunction *BF,
                                                            Function *F) {
-  SmallVector<MDNode *, 1> RegisterAllocModeMDs;
-  F->getMetadata("RegisterAllocMode", RegisterAllocModeMDs);
+  SmallVector<MDNode *, 1> MaximumRegistersMDs;
+  F->getMetadata("MaximumRegisters", MaximumRegistersMDs);
 
-  for (unsigned I = 0; I < RegisterAllocModeMDs.size(); I++) {
-    auto *RegisterAllocMode = RegisterAllocModeMDs[I]->getOperand(0).get();
-    if (isa<MDString>(RegisterAllocMode)) {
-      StringRef Str = getMDOperandAsString(RegisterAllocModeMDs[I], 0);
+  for (unsigned I = 0; I < MaximumRegistersMDs.size(); I++) {
+    auto *MaximumRegisters = MaximumRegistersMDs[I]->getOperand(0).get();
+    if (isa<MDString>(MaximumRegisters)) {
+      StringRef Str = getMDOperandAsString(MaximumRegistersMDs[I], 0);
       NamedMaximumNumberOfRegisters NamedValue =
           SPIRVNamedMaximumNumberOfRegistersNameMap::rmap(Str.str());
       BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
           OpExecutionMode, BF, ExecutionModeNamedMaximumRegistersINTEL,
           NamedValue)));
-    } else if (isa<MDNode>(RegisterAllocMode)) {
-      auto *RegisterAllocNodeMDOp =
-          getMDOperandAsMDNode(RegisterAllocModeMDs[I], 0);
-      int Num = getMDOperandAsInt(RegisterAllocNodeMDOp, 0);
+    } else if (isa<MDNode>(MaximumRegisters)) {
+      auto *MaxRegNodeMDOp =
+          getMDOperandAsMDNode(MaximumRegistersMDs[I], 0);
+      int Num = getMDOperandAsInt(MaxRegNodeMDOp, 0);
       auto *Const =
           BM->addConstant(transType(Type::getInt32Ty(F->getContext())), Num);
       BF->addExecutionMode(BM->add(new SPIRVExecutionModeId(
           BF, ExecutionModeMaximumRegistersIdINTEL, Const->getId())));
     } else {
-      int64_t RegisterAllocVal =
-          mdconst::dyn_extract<ConstantInt>(RegisterAllocMode)->getZExtValue();
+      int64_t MaxRegVal =
+          mdconst::dyn_extract<ConstantInt>(MaximumRegisters)->getZExtValue();
       BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
           OpExecutionMode, BF, ExecutionModeMaximumRegistersINTEL,
-          RegisterAllocVal)));
+          MaxRegVal)));
     }
   }
 }

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -108,6 +108,12 @@ public:
     case DecorationCounterBuffer:
       return VersionNumber::SPIRV_1_4;
 
+    case DecorationUniform:
+    case DecorationUniformId:
+      if (Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_6))
+        return VersionNumber::SPIRV_1_6;
+      return VersionNumber::SPIRV_1_0;
+
     default:
       return VersionNumber::SPIRV_1_0;
     }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -537,6 +537,17 @@ std::vector<SPIRVDecorate const *> SPIRVEntry::getDecorations() const {
   return Decors;
 }
 
+std::vector<SPIRVDecorateGeneric const *>
+SPIRVEntry::getAllDecorations() const {
+  std::vector<SPIRVDecorateGeneric const *> Decors;
+  Decors.reserve(Decorates.size() + DecorateIds.size());
+  for (auto &DecoPair : Decorates)
+    Decors.push_back(DecoPair.second);
+  for (auto &DecoPair : DecorateIds)
+    Decors.push_back(DecoPair.second);
+  return Decors;
+}
+
 std::set<SPIRVId> SPIRVEntry::getDecorateId(Decoration Kind,
                                             size_t Index) const {
   auto Range = DecorateIds.equal_range(Kind);

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -60,6 +60,7 @@ class SPIRVEncoder;
 class SPIRVDecoder;
 class SPIRVType;
 class SPIRVValue;
+class SPIRVDecorateGeneric;
 class SPIRVDecorate;
 class SPIRVDecorateId;
 class SPIRVForward;
@@ -319,6 +320,7 @@ public:
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   std::vector<SPIRVDecorate const *> getDecorations(Decoration Kind) const;
   std::vector<SPIRVDecorate const *> getDecorations() const;
+  std::vector<SPIRVDecorateGeneric const *> getAllDecorations() const;
   std::set<SPIRVId> getDecorateId(Decoration Kind, size_t Index = 0) const;
   std::vector<SPIRVDecorateId const *> getDecorationIds(Decoration Kind) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }

--- a/test/DecorateUniformIdRoundTrip.spt
+++ b/test/DecorateUniformIdRoundTrip.spt
@@ -1,0 +1,43 @@
+; Check that a UniformId decoration on an OpVariable survives a -r round
+; trip: it must show up as !spirv.Decorations metadata with the resolved
+; scope value (not the SPIR-V id of the scope constant), and translating
+; that metadata back to SPIR-V must produce a valid module again with the
+; Scope operand restored to the correct value.
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv %t.rev.bc -o %t.fwd.spv
+; RUN: spirv-val %t.fwd.spv
+; RUN: llvm-spirv %t.fwd.spv -to-text -o %t.fwd.spt
+; RUN: FileCheck < %t.fwd.spt %s --check-prefix=CHECK-SPIRV
+
+; CHECK-LLVM: global i32 0, !spirv.Decorations ![[DECOS:[0-9]+]]
+; CHECK-LLVM: ![[DECOS]] = !{![[DECO:[0-9]+]]}
+; CHECK-LLVM: ![[DECO]] = !{i32 27, i32 2}
+
+; CHECK-SPIRV: DecorateId {{[0-9]+}} UniformId [[SCOPE:[0-9]+]]
+; CHECK-SPIRV: Constant {{[0-9]+}} [[SCOPE]] 2
+
+119734787 67072 458752 9 0
+
+2 Capability Addresses
+2 Capability Kernel
+2 Capability UniformDecoration
+3 MemoryModel 2 2
+5 EntryPoint 6 1 "test"
+
+4 DecorateId 2 UniformId 3    ; %var UniformId %scope
+
+4 TypeInt 4 32 0              ; %uint = OpTypeInt 32 0
+4 Constant 4 3 2              ; %scope = OpConstant %uint 2
+4 TypePointer 5 5 4           ; %uint_ptr = OpTypePointer CrossWorkgroup %uint
+2 TypeVoid 6                  ; %void = OpTypeVoid
+3 TypeFunction 7 6            ; %1 = OpTypeFunction %void
+4 Variable 5 2 5              ; %var = OpVariable %uint_ptr CrossWorkgroup
+
+5 Function 6 1 0 7            ; %2 = OpFunction %void None %1
+2 Label 8                     ; %3 = OpLabel
+1 Return
+1 FunctionEnd

--- a/test/DecorateUniformIdWriter.ll
+++ b/test/DecorateUniformIdWriter.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; Check that a UniformId decoration expressed as !spirv.Decorations metadata
+; (kind 27, per the SPIR-V grammar) is emitted as OpDecorateId with a Scope
+; id operand, not as a plain OpDecorate with a literal operand.
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+@var = addrspace(1) global i32 0, !spirv.Decorations !1
+
+; CHECK: DecorateId [[#TARGET:]] UniformId [[#SCOPE:]]
+; CHECK-NOT: Decorate {{[0-9]+}} UniformId
+; CHECK: TypeInt [[#UINT:]] 32 0
+; CHECK: Constant [[#UINT]] [[#SCOPE]] 2
+; CHECK: Variable {{[0-9]+}} [[#TARGET]]
+
+!1 = !{!2}
+!2 = !{i32 27, i32 2}

--- a/test/extensions/INTEL/SPV_INTEL_function_pointers/ptr-equal-type-mismatch.ll
+++ b/test/extensions/INTEL/SPV_INTEL_function_pointers/ptr-equal-type-mismatch.ll
@@ -1,0 +1,42 @@
+; Check that comparing differently-typed pointers inserts a Bitcast to
+; unify operand types before OpPtrEqual/OpPtrNotEqual, as required by the
+; SPIR-V spec.
+
+; RUN: llvm-spirv %s --spirv-ext=+SPV_INTEL_function_pointers -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %s --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG: Name [[#ARG:]] "arg"
+; CHECK-SPIRV-DAG: Name [[#A2:]] "a"
+; CHECK-SPIRV-DAG: Name [[#B2:]] "b"
+; CHECK-SPIRV-DAG: TypeFunction [[#FOOTY:]] [[#]] [[#]]
+; CHECK-SPIRV-DAG: TypePointer [[#FUNPTRTY:]] {{[0-9]+}} [[#FOOTY]]
+; CHECK-SPIRV: ConstantFunctionPointerINTEL [[#FUNPTRTY]] [[#FOOPTR:]] [[#]]
+
+; CHECK-SPIRV: Bitcast [[#FUNPTRTY]] [[#ARGCAST:]] [[#ARG]]
+; CHECK-SPIRV: PtrEqual [[#]] [[#]] [[#FOOPTR]] [[#ARGCAST]]
+
+; CHECK-SPIRV: Bitcast [[#]] [[#B2CAST:]] [[#B2]]
+; CHECK-SPIRV: PtrNotEqual [[#]] [[#]] [[#A2]] [[#B2CAST]]
+
+define spir_func i32 @foo(i32 %v) {
+  ret i32 %v
+}
+
+define spir_func i1 @test(ptr %arg) {
+  %val = load i32, ptr %arg
+  %cmp = icmp eq ptr @foo, %arg
+  ret i1 %cmp
+}
+
+; Same mismatch without function pointers involved.
+define spir_func i1 @test2(ptr %a, ptr %b) {
+  %la = load i32, ptr %a
+  %lb = load float, ptr %b
+  %cmp = icmp ne ptr %a, %b
+  ret i1 %cmp
+}

--- a/test/extensions/INTEL/SPV_INTEL_maximum_registers/maxreg_extension.ll
+++ b/test/extensions/INTEL/SPV_INTEL_maximum_registers/maxreg_extension.ll
@@ -11,45 +11,45 @@
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC3:]] "main_l13"
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC4:]] "main_l19"
 
-; CHECK-SPIRV: ExecutionMode [[#FUNC0]] 6461 2
-; CHECK-SPIRV: ExecutionMode [[#FUNC1]] 6461 1
+; CHECK-SPIRV: ExecutionMode [[#FUNC0]] 6461 256
+; CHECK-SPIRV: ExecutionMode [[#FUNC1]] 6461 128
 ; CHECK-SPIRV: ExecutionMode [[#FUNC2]] 6463 0
 ; CHECK-SPIRV: ExecutionModeId [[#FUNC3]] 6462 [[#Const3:]]
 ; CHECK-SPIRV: TypeInt [[#TypeInt:]] 32 0
-; CHECK-SPIRV: Constant [[#TypeInt]] [[#Const3]] 3
+; CHECK-SPIRV: Constant [[#TypeInt]] [[#Const3]] 512
 
 ; CHECK-SPIRV-NOT: ExecutionMode [[#FUNC4]]
 
 ; CHECK-LLVM: !spirv.ExecutionMode = !{![[#FLAG0:]], ![[#FLAG1:]], ![[#FLAG2:]], ![[#FLAG3:]]}
-; CHECK-LLVM: ![[#FLAG0]] = !{ptr @main_l3, i32 6461, i32 2}
-; CHECK-LLVM: ![[#FLAG1]] = !{ptr @main_l6, i32 6461, i32 1}
+; CHECK-LLVM: ![[#FLAG0]] = !{ptr @main_l3, i32 6461, i32 256}
+; CHECK-LLVM: ![[#FLAG1]] = !{ptr @main_l6, i32 6461, i32 128}
 ; CHECK-LLVM: ![[#FLAG2]] = !{ptr @main_l9, i32 6463, !"AutoINTEL"}
 ; CHECK-LLVM: ![[#FLAG3]] = !{ptr @main_l13, i32 6462, ![[#VAL:]]}
-; CHECK-LLVM: ![[#VAL]] = !{i32 3}
+; CHECK-LLVM: ![[#VAL]] = !{i32 512}
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l3() #0 !RegisterAllocMode !10 {
+define weak dso_local spir_kernel void @main_l3() #0 !MaximumRegisters !10 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l6() #0 !RegisterAllocMode !11 {
+define weak dso_local spir_kernel void @main_l6() #0 !MaximumRegisters !11 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l9() #0 !RegisterAllocMode !12 {
+define weak dso_local spir_kernel void @main_l9() #0 !MaximumRegisters !12 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l13() #0 !RegisterAllocMode !13 {
+define weak dso_local spir_kernel void @main_l13() #0 !MaximumRegisters !13 {
 newFuncRoot:
   ret void
 }
@@ -78,8 +78,8 @@ attributes #0 = { noinline nounwind optnone }
 !7 = !{i32 8, !"PIC Level", i32 2}
 !8 = !{i32 7, !"frame-pointer", i32 2}
 !9 = !{i32 2, i32 2}
-!10 = !{i32 2}
-!11 = !{i32 1}
+!10 = !{i32 256}
+!11 = !{i32 128}
 !12 = !{!"AutoINTEL"}
 !13 = !{!14}
-!14 = !{i32 3}
+!14 = !{i32 512}

--- a/test/phi-duplicate-predecessors.ll
+++ b/test/phi-duplicate-predecessors.ll
@@ -1,0 +1,30 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: spirv-dis %t.spv | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.rev.bc -r --spirv-target-env=SPV-IR
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck --input-file=%t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: %[[Entry:[a-zA-Z0-9_]+]] = OpLabel
+; CHECK-SPIRV: OpBranch %[[Label:[a-zA-Z0-9_]+]]
+; CHECK-SPIRV: %[[Label]] = OpLabel
+; CHECK-SPIRV: %{{.*}} = OpPhi %{{.*}} %{{.*}} %[[Entry]]
+
+; CHECK-LLVM-LABEL: define spir_kernel void @f()
+; CHECK-LLVM:       [[Entry:[a-zA-Z0-9_]+]]:
+; CHECK-LLVM:       br label %[[Label:[a-zA-Z0-9_]+]]
+; CHECK-LLVM:       [[Label]]:
+; CHECK-LLVM:       %[[PHI:[a-zA-Z0-9_]+]] = phi i64 [ 0, %[[Entry]] ]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @f() {
+entry:
+  br i1 undef, label %L815, label %L815
+
+L815:                                             ; preds = %entry, %entry
+  %v = phi i64 [ 0, %entry ], [ 0, %entry ]
+  ret void
+}

--- a/test/transcoding/registerallocmode.ll
+++ b/test/transcoding/registerallocmode.ll
@@ -3,6 +3,15 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Verify we don't use SPV_INTEL_maximum_registers even if it is allowed.
+; The MaximumRegisters metadata should be used for SPV_INTEL_maximum_registers.
+
+; RUN: llvm-as %s -o %t2.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_maximum_registers -spirv-text %t2.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV -implicit-check-not=SPV_INTEL_maximum_registers
+; RUN: llvm-spirv %t2.bc -o %t2.spv
+; RUN: spirv-val %t2.spv
+; RUN: llvm-spirv -r %t2.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM -implicit-check-not=spirv.ExecutionMode
 ; FIXME: llc does not emit UserSemantic decorations for RegisterAllocMode/num-thread-per-eu annotations, so these are lost in the roundtrip
 
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC0:]] "main_l3"


### PR DESCRIPTION
Manual upstream merge of KhronosGroup/SPIRV-LLVM-Translator `main` into `amd-staging`.

The automated `upstream-merge` workflow has been aborting since 2026-08-11 (no PR created) due to a merge conflict in `lib/SPIRV/SPIRVWriter.cpp`.

**Conflict & resolution**

Single conflict in `LLVMToSPIRVBase::transCmpInst`. AMD carries a downstream patch (#2511) that added `OpPtrEqual`/`OpPtrNotEqual` translation plus a bitcast-on-type-mismatch fix. Upstream then landed the equivalent via #3947 ("Fix assertion on OpPtrEqual/OpPtrNotEqual with mismatched pointer types"), which also added a local `Op1` variable. The two versions are functionally identical; git could not auto-merge the overlapping edits.

Resolved by taking upstream's version of the hunk. After resolution, `transCmpInst` is byte-identical to `upstream/main`, so this conflict will not recur. The two test files added by #3947 auto-merged cleanly.

Follow-up worth considering: drop the now-superseded downstream #2511 changes so the region stays aligned with upstream.

> [!IMPORTANT]
> Merge with **"Create a merge commit"**, not squash — squashing destroys the upstream ancestry link and causes conflicts on every future merge.