### PR TITLE
ci: switch SPIRV CI Linux runners to aws-linux-scale-rocm-large

### DIFF
--- a/.github/workflows/spirv-ci-linux.yml
+++ b/.github/workflows/spirv-ci-linux.yml
@@ -35,7 +35,7 @@ jobs:
   # =====================================================================
   build:
     name: Build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 120
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -357,7 +357,7 @@ jobs:
   test_translator_lit:
     name: Test SPIRV translator lit
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -464,7 +464,7 @@ jobs:
   test_codegen:
     name: Test LLVM SPIRV codegen
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 15
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
@@ -507,7 +507,7 @@ jobs:
   test_comgr:
     name: Test Comgr
     needs: build
-    runs-on: azure-linux-scale-rocm
+    runs-on: aws-linux-scale-rocm-large
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421


### PR DESCRIPTION
Switch the Linux CPU build/test jobs in the SPIRV PR CI from the `azure-linux-scale-rocm` runner pool to `aws-linux-scale-rocm-large`.

The GPU test runners and the Windows workflow are unchanged.
