### PR TITLE
Upstream merge 2026-08-17 (manual conflict resolution)

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -176,6 +176,13 @@ struct SpecConstInfoTy {
 bool getSpecConstInfo(std::istream &IS,
                       std::vector<SpecConstInfoTy> &SpecConstInfo);
 
+/// \brief Partially load SPIR-V from the stream and decode only instructions
+/// needed to get information about specialization constants, using the
+/// specified options.
+/// \returns true if succeeds.
+bool getSpecConstInfo(std::istream &IS, const SPIRV::TranslatorOpts &Opts,
+                      std::vector<SpecConstInfoTy> &SpecConstInfo);
+
 /// \brief Convert a SPIRVModule into LLVM IR.
 /// \returns null on failure.
 std::unique_ptr<Module>

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -135,6 +135,13 @@ enum SPIRAddressSpace : uint32_t {
 
 using AddrSpaceMap = std::array<uint32_t, SPIRAS_Count>;
 
+/// \brief What the translator does with a module it cannot accept.
+///
+/// Ignore leaves the failure to be reported through the return value and the
+/// error string of the entry point, typical for embedded uses. Abort and Exit
+/// terminate the process, typical for standalone tools.
+enum class SPIRVDbgErrorHandlingKinds { Abort, Exit, Ignore };
+
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
 public:
@@ -338,6 +345,13 @@ public:
   // success, false on failure.
   bool validateFnVarOpts() const;
 
+  SPIRVDbgErrorHandlingKinds getErrorHandlingKind() const noexcept {
+    return ErrorHandling;
+  }
+  void setErrorHandlingKind(SPIRVDbgErrorHandlingKinds Kind) noexcept {
+    ErrorHandling = Kind;
+  }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -366,6 +380,9 @@ private:
   // Unknown LLVM intrinsics will be translated as external function calls in
   // SPIR-V
   std::optional<ArgList> SPIRVAllowUnknownIntrinsics{};
+
+  // What to do with a module the translator cannot accept.
+  SPIRVDbgErrorHandlingKinds ErrorHandling = SPIRVDbgErrorHandlingKinds::Exit;
 
   // Enable support for extra DIExpression opcodes not listed in the SPIR-V
   // DebugInfo specification.

--- a/lib/SPIRV/SPIRVLowerLLVMIntrinsic.cpp
+++ b/lib/SPIRV/SPIRVLowerLLVMIntrinsic.cpp
@@ -165,11 +165,11 @@ void SPIRVLowerLLVMIntrinsicBase::visitIntrinsicInst(CallInst &I) {
     I.setCalledFunction(F);
     return;
   }
-  FunctionCallee FC =
-      Mod->getOrInsertFunction(SPIRVFuncName, I.getFunctionType());
-  I.setCalledFunction(FC);
-
-  // Read LLVM IR with the intrinsic's implementation
+  // Read LLVM IR with the intrinsic's implementation. Do this before
+  // redirecting the call: if the module does not parse, the call must keep
+  // targeting the intrinsic, so that the failure surfaces through the
+  // writer's handling of the unlowered intrinsic instead of a call to a
+  // function that never receives a body.
   SMDiagnostic Err;
   auto MB = MemoryBuffer::getMemBuffer(MapEntry->ModuleText);
   auto EmulationModule = parseIR(MB->getMemBufferRef(), Err, *Context,
@@ -181,9 +181,14 @@ void SPIRVLowerLLVMIntrinsicBase::visitIntrinsicInst(CallInst &I) {
     raw_string_ostream ErrStream(ErrMsg);
     Err.print("", ErrStream);
     SPIRVErrorLog EL;
+    EL.setErrorHandlingKind(Opts.getErrorHandlingKind());
     EL.checkError(false, SPIRVEC_InvalidLlvmModule, ErrMsg);
     return;
   }
+
+  FunctionCallee FC =
+      Mod->getOrInsertFunction(SPIRVFuncName, I.getFunctionType());
+  I.setCalledFunction(FC);
 
   // Link in the intrinsic's implementation.
   if (!Linker::linkModules(*Mod, std::move(EmulationModule),

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -6117,9 +6117,8 @@ bool llvm::readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
   return true;
 }
 
-bool llvm::getSpecConstInfo(std::istream &IS,
-                            std::vector<SpecConstInfoTy> &SpecConstInfo) {
-  std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
+static bool getSpecConstInfoImpl(std::istream &IS, SPIRVModule *BM,
+                                 std::vector<SpecConstInfoTy> &SpecConstInfo) {
   BM->setAutoAddExtensions(false);
   SPIRVDecoder D(IS, *BM);
   SPIRVWord Magic;
@@ -6196,6 +6195,18 @@ bool llvm::getSpecConstInfo(std::istream &IS,
     }
   }
   return !IS.bad();
+}
+
+bool llvm::getSpecConstInfo(std::istream &IS,
+                            std::vector<SpecConstInfoTy> &SpecConstInfo) {
+  std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
+  return getSpecConstInfoImpl(IS, BM.get(), SpecConstInfo);
+}
+
+bool llvm::getSpecConstInfo(std::istream &IS, const SPIRV::TranslatorOpts &Opts,
+                            std::vector<SpecConstInfoTy> &SpecConstInfo) {
+  std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule(Opts));
+  return getSpecConstInfoImpl(IS, BM.get(), SpecConstInfo);
 }
 
 // clang-format off

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -40,6 +40,7 @@
 #ifndef SPIRV_LIBSPIRV_SPIRVDEBUG_H
 #define SPIRV_LIBSPIRV_SPIRVDEBUG_H
 
+#include "LLVMSPIRVOpts.h"
 #include "SPIRVUtil.h"
 
 #include <iostream>
@@ -54,8 +55,9 @@ namespace SPIRV {
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
 
-// Enable assert or exit on error
-enum class SPIRVDbgErrorHandlingKinds { Abort, Exit, Ignore };
+// Enable assert or exit on error. Supplies the default for SPIRVErrorLog
+// instances created without TranslatorOpts, e.g. by the no-options
+// getSpecConstInfo overload.
 extern SPIRVDbgErrorHandlingKinds SPIRVDbgError;
 
 // Enable debug output.

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -101,6 +101,11 @@ public:
     ErrorCode = ErrCode;
     ErrorMsg = ErrMsg;
   }
+  // Select what happens when a check fails. Defaults to the SPIRVDbgError
+  // global; SPIRVModule overrides it from TranslatorOpts.
+  void setErrorHandlingKind(SPIRVDbgErrorHandlingKinds Kind) {
+    ErrorHandling = Kind;
+  }
   // Check if Condition is satisfied and set ErrCode and DetailedMsg
   // if not. Returns true if no error.
   bool checkError(bool Condition, SPIRVErrorCode ErrCode,
@@ -122,6 +127,7 @@ public:
 protected:
   SPIRVErrorCode ErrorCode;
   std::string ErrorMsg;
+  SPIRVDbgErrorHandlingKinds ErrorHandling = SPIRVDbgError;
 };
 
 inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
@@ -164,7 +170,7 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
   if (SPIRVDbgErrorMsgIncludesSourceInfo && FileName)
     SS << " [Src: " << FileName << ":" << LineNo << " " << CondString << " ]";
   setError(ErrCode, SS.str());
-  switch (SPIRVDbgError) {
+  switch (ErrorHandling) {
   case SPIRVDbgErrorHandlingKinds::Abort:
     std::cerr << SS.str() << std::endl;
     abort();
@@ -174,12 +180,13 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
     std::exit(ErrCode);
     break;
   case SPIRVDbgErrorHandlingKinds::Ignore:
-    // Still print info about the error into debug output stream
-    // TODO: The value Ignore is not currently used but if it would be used
-    // then places where this routine is called must be checked as just
-    // ignoring the error may lead to NULL pointer dereferences
-    spvdbgs() << SS.str() << '\n';
-    spvdbgs().flush();
+    // The caller reads the failure back through getError(), so say nothing
+    // unless debug output was asked for. An embedder selects this kind
+    // precisely to keep the failure out of the process' stderr.
+    if (SPIRVDbgEnable) {
+      spvdbgs() << SS.str() << '\n';
+      spvdbgs().flush();
+    }
     break;
   }
   return Cond;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -94,6 +94,7 @@ public:
   SPIRVModuleImpl(const SPIRV::TranslatorOpts &Opts) : SPIRVModuleImpl() {
     TranslationOpts = Opts;
     MaxVersion = Opts.getMaxVersion();
+    ErrLog.setErrorHandlingKind(Opts.getErrorHandlingKind());
   }
 
   ~SPIRVModuleImpl() override;
@@ -2570,7 +2571,7 @@ std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
     SPIRVDBG(spvdbgs() << "Read word: W = " << W << " V = 0\n");
     return W;
   };
-  SPIRVErrorLog ErrorLog = MI.getErrorLog();
+  SPIRVErrorLog &ErrorLog = MI.getErrorLog();
   SPIRVWord Magic = ReadSPIRVWord(I);
 
   if (!ErrorLog.checkError(!I.eof(), SPIRVEC_InvalidModule,

--- a/test/negative/spirv_reader_error_handling.ll
+++ b/test/negative/spirv_reader_error_handling.ll
@@ -1,0 +1,38 @@
+; readSpirv() is documented to report a rejected module by returning false and
+; filling in an error string. It instead reaches std::exit() through
+; SPIRVErrorLog::checkError(), because the error handling kind was a global
+; defaulting to Exit, so the caller's error handling never ran.
+;
+; Check that the kind is selectable through TranslatorOpts, and that the non
+; fatal kind both keeps the process alive and carries the reason out to the
+; caller.
+;
+; RUN: echo 'not a SPIR-V module' > %t.spv
+; RUN: not llvm-spirv -r --spirv-error-handling=ignore %t.spv -o %t.bc 2>&1 | FileCheck %s
+;
+; The reason has to survive the call, and nothing may be written to stderr
+; ahead of the caller's own diagnostic.
+; CHECK-NOT: {{.}}
+; CHECK: Fails to load SPIR-V as LLVM Module: InvalidModule: Invalid SPIR-V module: invalid magic number
+;
+; The spec constant scan takes the same selection through TranslatorOpts: under
+; ignore the scan reports failure through its return value and the tool prints
+; its own diagnostic.
+; RUN: not llvm-spirv --spec-const-info --spirv-error-handling=ignore %t.spv 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-SPEC-IGNORE
+; CHECK-SPEC-IGNORE-NOT: InvalidModule
+; CHECK-SPEC-IGNORE: Invalid SPIR-V binary
+;
+; Under the default, exit, the process terminates inside the scan with the
+; error on stderr, before the tool's own diagnostic is reached.
+; RUN: not llvm-spirv --spec-const-info %t.spv 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-SPEC-EXIT
+; CHECK-SPEC-EXIT: InvalidModule: Invalid SPIR-V module: invalid magic number
+; CHECK-SPEC-EXIT-NOT: Invalid SPIR-V binary
+;
+; The -spec-const option runs the same scan; under ignore its failure must
+; still produce a diagnostic rather than a bare nonzero exit.
+; RUN: not llvm-spirv -r -spec-const=0:i32:1 --spirv-error-handling=ignore \
+; RUN:   %t.spv -o %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-SPECOPT-IGNORE
+; CHECK-SPECOPT-IGNORE-NOT: InvalidModule
+; CHECK-SPECOPT-IGNORE: Invalid SPIR-V binary

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -145,6 +145,18 @@ static cl::opt<SPIRV::ExtInst> ExtInst(
                           "OpenCL.std extended instruction set")),
     cl::init(SPIRV::ExtInst::None));
 
+static cl::opt<SPIRV::SPIRVDbgErrorHandlingKinds> ErrorHandling(
+    "spirv-error-handling",
+    cl::desc("Specify what happens when a module is rejected"),
+    cl::values(clEnumValN(SPIRV::SPIRVDbgErrorHandlingKinds::Abort, "abort",
+                          "Print the error and abort"),
+               clEnumValN(SPIRV::SPIRVDbgErrorHandlingKinds::Exit, "exit",
+                          "Print the error and exit with its error code"),
+               clEnumValN(SPIRV::SPIRVDbgErrorHandlingKinds::Ignore, "ignore",
+                          "Suppress the translator's own error message and "
+                          "exit through the tool's normal error path")),
+    cl::init(SPIRV::SPIRVDbgErrorHandlingKinds::Exit));
+
 static cl::opt<SPIRV::BIsRepresentation> BIsRepresentation(
     "spirv-target-env",
     cl::desc("Specify a representation of different SPIR-V Instructions which "
@@ -643,8 +655,10 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
                        SPIRV::TranslatorOpts &Opts) {
   std::ifstream IFS(InputFile, std::ios::binary);
   std::vector<SpecConstInfoTy> SpecConstInfo;
-  if (!getSpecConstInfo(IFS, SpecConstInfo))
+  if (!getSpecConstInfo(IFS, Opts, SpecConstInfo)) {
+    errs() << "Invalid SPIR-V binary\n";
     return true;
+  }
 
   SmallVector<StringRef, 8> Split;
   SpecConstStr.split(Split, ' ', -1, false);
@@ -899,6 +913,8 @@ int main(int Ac, char **Av) {
 
   Opts.setFPContractMode(FPCMode);
 
+  Opts.setErrorHandlingKind(ErrorHandling);
+
   if (SPIRVBuiltinFormat.getNumOccurrences() != 0) {
     if (!IsReverse) {
       errs() << "Note: --spirv-builtin-format option ignored as it only "
@@ -1071,7 +1087,7 @@ int main(int Ac, char **Av) {
   if (SpecConstInfo) {
     std::ifstream IFS(InputFile, std::ios::binary);
     std::vector<SpecConstInfoTy> SpecConstInfo;
-    if (!getSpecConstInfo(IFS, SpecConstInfo)) {
+    if (!getSpecConstInfo(IFS, Opts, SpecConstInfo)) {
       std::cout << "Invalid SPIR-V binary";
       return -1;
     }


### PR DESCRIPTION
Manual resolution of the automated upstream merge that hit a conflict on 2026-08-17 (workflow run [32009886450](https://github.com/ROCm/SPIRV-LLVM-Translator/actions/runs/32009886450) — "⚠️ Merge Conflicts Detected").

Merges upstream `KhronosGroup/SPIRV-LLVM-Translator` main into `amd-staging`. One upstream commit since the last merge:

- `1e5eb1f9` Make the error handling kind selectable through TranslatorOpts (#3941)

### Conflict

Single conflict in `include/LLVMSPIRVOpts.h`: both sides added public accessors to `TranslatorOpts` immediately before the `private:` label.

- **ours (amd-staging):** `set/getAMDGCNSPIRVOffloadArch`
- **upstream:** `get/setErrorHandlingKind`

Resolved keep-both — both accessor blocks retained, single `private:`. The backing members (`AMDGCNSPIRVOffloadArch`, `ErrorHandling`) and the `SPIRVDbgErrorHandlingKinds` enum merged cleanly; the other 8 files in the upstream commit auto-merged.

> [!IMPORTANT]
> Merge with **"Create a merge commit"**, not squash — squashing destroys the upstream ancestry link and causes conflicts on every future merge.
