### PR TITLE
Replace removed GlobalVariable::getAlignment() with getAlign()

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3528,7 +3528,8 @@ bool LLVMToSPIRVBase::transAlign(Value *V, SPIRVValue *BV) {
     return true;
   }
   if (auto *GV = dyn_cast<GlobalVariable>(V)) {
-    BM->setAlignment(BV, GV->getAlignment());
+    if (MaybeAlign Alignment = GV->getAlign())
+      BM->setAlignment(BV, Alignment->value());
     return true;
   }
   return true;


### PR DESCRIPTION
`amd-staging` picked up a newer upstream LLVM (via merge #279) that removed `GlobalVariable::getAlignment()`, breaking `transAlign()` in `SPIRVWriter.cpp`. This replaces it with the stable `getAlign()` API, preserving the old "0 when no explicit alignment" behavior.

Landed ahead of upstream `KhronosGroup/SPIRV-LLVM-Translator#3976`; will reconcile cleanly when that flows down via the upstream-merge workflow.